### PR TITLE
New initialization syste

### DIFF
--- a/src/main/java/me/hydos/rosella/Rosella.java
+++ b/src/main/java/me/hydos/rosella/Rosella.java
@@ -1,6 +1,6 @@
 package me.hydos.rosella;
 
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.device.VulkanQueues;
 import me.hydos.rosella.display.Display;
 import me.hydos.rosella.logging.DebugLogger;
@@ -59,7 +59,7 @@ public class Rosella {
         common.display = display;
         common.vkInstance = new VulkanInstance(requestedValidationLayers, requiredExtensions, applicationName, debugLogger);
         common.surface = display.createSurface(common);
-        common.device = new VulkanDevice(common, requestedValidationLayers);
+        common.device = new LegacyVulkanDevice(common, requestedValidationLayers);
         common.queues = new VulkanQueues(common);
         common.memory = new ThreadPoolMemory(common);
         common.semaphorePool = new SemaphorePool(common.device.rawDevice);

--- a/src/main/java/me/hydos/rosella/Rosella.java
+++ b/src/main/java/me/hydos/rosella/Rosella.java
@@ -12,7 +12,7 @@ import me.hydos.rosella.scene.object.ObjectManager;
 import me.hydos.rosella.scene.object.impl.SimpleObjectManager;
 import me.hydos.rosella.util.SemaphorePool;
 import me.hydos.rosella.vkobjects.VkCommon;
-import me.hydos.rosella.vkobjects.VulkanInstance;
+import me.hydos.rosella.vkobjects.LegacyVulkanInstance;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -57,7 +57,7 @@ public class Rosella {
 
         // Setup core vulkan stuff
         common.display = display;
-        common.vkInstance = new VulkanInstance(requestedValidationLayers, requiredExtensions, applicationName, debugLogger);
+        common.vkInstance = new LegacyVulkanInstance(requestedValidationLayers, requiredExtensions, applicationName, debugLogger);
         common.surface = display.createSurface(common);
         common.device = new LegacyVulkanDevice(common, requestedValidationLayers);
         common.queues = new VulkanQueues(common);

--- a/src/main/java/me/hydos/rosella/Rosella.java
+++ b/src/main/java/me/hydos/rosella/Rosella.java
@@ -74,7 +74,7 @@ public class Rosella {
         this.vulkanDevice = new DeviceBuilder(this.vulkanInstance, registry).build();
         common.device = new LegacyVulkanDevice(this.vulkanDevice);
 
-        RosellaLegacy.RosellaLegacyFeatures legacyFeatures = RosellaLegacy.getMetaObject(this.vulkanDevice.getFeatureMeta(RosellaLegacy.NAME));
+        RosellaLegacy.RosellaLegacyFeatures legacyFeatures = RosellaLegacy.getMetadata(this.vulkanDevice);
         try {
             common.queues = new VulkanQueues(legacyFeatures.graphicsQueue().get(), legacyFeatures.presentQueue().get());
         } catch (Exception ex) {
@@ -116,7 +116,7 @@ public class Rosella {
 
         common.device = new LegacyVulkanDevice(common.vkInstance.newInstance, initializationRegistry);
 
-        RosellaLegacy.RosellaLegacyFeatures legacyFeatures = RosellaLegacy.getMetaObject(common.device.newDevice.getFeatureMeta(RosellaLegacy.NAME));
+        RosellaLegacy.RosellaLegacyFeatures legacyFeatures = RosellaLegacy.getMetadata(common.device.newDevice);
         try {
             common.queues = new VulkanQueues(legacyFeatures.graphicsQueue().get(), legacyFeatures.presentQueue().get());
         } catch (Exception ex) {

--- a/src/main/java/me/hydos/rosella/debug/LegacyDebugCallback.java
+++ b/src/main/java/me/hydos/rosella/debug/LegacyDebugCallback.java
@@ -1,0 +1,25 @@
+package me.hydos.rosella.debug;
+
+import me.hydos.rosella.logging.DebugLogger;
+import org.lwjgl.vulkan.VkDebugUtilsMessengerCallbackDataEXT;
+
+public class LegacyDebugCallback extends VulkanDebugCallback.Callback {
+
+    private DebugLogger logger;
+
+    public LegacyDebugCallback(DebugLogger logger) {
+        super(MessageSeverity.allBits(), MessageType.allBits());
+        this.logger = logger;
+    }
+
+    @Override
+    protected void callInternal(MessageSeverity severity, MessageType type, VkDebugUtilsMessengerCallbackDataEXT data) {
+        String message = data.pMessageString();
+
+        switch(type) {
+            case GENERAL -> this.logger.logGeneral(severity.name, message);
+            case VALIDATION -> this.logger.logValidation(severity.name, message);
+            case PERFORMANCE -> this.logger.logPerformance(severity.name, message);
+        }
+    }
+}

--- a/src/main/java/me/hydos/rosella/debug/MessageSeverity.java
+++ b/src/main/java/me/hydos/rosella/debug/MessageSeverity.java
@@ -1,0 +1,34 @@
+package me.hydos.rosella.debug;
+
+import org.lwjgl.vulkan.EXTDebugUtils;
+
+public enum MessageSeverity {
+    VERBOSE(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT),
+    INFO(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT),
+    WARNING(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT),
+    ERROR(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT);
+
+    public final int bits;
+
+    MessageSeverity(int bits) {
+        this.bits = bits;
+    }
+
+    public boolean isInMask(int mask) {
+        return (mask & this.bits) == this.bits;
+    }
+
+    public static int allBits() {
+        return VERBOSE.bits | INFO.bits | WARNING.bits | ERROR.bits;
+    }
+
+    public static MessageSeverity fromBits(int bits) {
+        return switch(bits) {
+            case EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT -> VERBOSE;
+            case EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT -> INFO;
+            case EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT -> WARNING;
+            case EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT -> ERROR;
+            default -> throw new RuntimeException("Bits are either a combination of bits or invalid");
+        };
+    }
+}

--- a/src/main/java/me/hydos/rosella/debug/MessageSeverity.java
+++ b/src/main/java/me/hydos/rosella/debug/MessageSeverity.java
@@ -3,19 +3,26 @@ package me.hydos.rosella.debug;
 import org.lwjgl.vulkan.EXTDebugUtils;
 
 public enum MessageSeverity {
-    VERBOSE(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT),
-    INFO(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT),
-    WARNING(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT),
-    ERROR(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT);
+    VERBOSE(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT, "VERBOSE"),
+    INFO(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT, "INFO"),
+    WARNING(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT, "WARNING"),
+    ERROR(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, "ERROR");
 
     public final int bits;
+    public final String name;
 
-    MessageSeverity(int bits) {
+    MessageSeverity(int bits, String name) {
         this.bits = bits;
+        this.name = name;
     }
 
     public boolean isInMask(int mask) {
         return (mask & this.bits) == this.bits;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
     }
 
     public static int allBits() {

--- a/src/main/java/me/hydos/rosella/debug/MessageType.java
+++ b/src/main/java/me/hydos/rosella/debug/MessageType.java
@@ -3,18 +3,25 @@ package me.hydos.rosella.debug;
 import org.lwjgl.vulkan.EXTDebugUtils;
 
 public enum MessageType {
-    GENERAL(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT),
-    VALIDATION(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT),
-    PERFORMANCE(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT);
+    GENERAL(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT, "GENERAL"),
+    VALIDATION(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT, "VALIDATION"),
+    PERFORMANCE(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT, "PERFORMANCE");
 
     public final int bits;
+    public final String name;
 
-    MessageType(int bits) {
+    MessageType(int bits, String name) {
         this.bits = bits;
+        this.name = name;
     }
 
     public boolean isInMask(int mask) {
         return (mask & this.bits) == this.bits;
+    }
+
+    @Override
+    public String toString() {
+        return name;
     }
 
     public static int allBits() {

--- a/src/main/java/me/hydos/rosella/debug/MessageType.java
+++ b/src/main/java/me/hydos/rosella/debug/MessageType.java
@@ -1,0 +1,32 @@
+package me.hydos.rosella.debug;
+
+import org.lwjgl.vulkan.EXTDebugUtils;
+
+public enum MessageType {
+    GENERAL(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT),
+    VALIDATION(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT),
+    PERFORMANCE(EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT);
+
+    public final int bits;
+
+    MessageType(int bits) {
+        this.bits = bits;
+    }
+
+    public boolean isInMask(int mask) {
+        return (mask & this.bits) == this.bits;
+    }
+
+    public static int allBits() {
+        return GENERAL.bits | VALIDATION.bits | PERFORMANCE.bits;
+    }
+
+    public static MessageType fromBits(int bits) {
+        return switch (bits) {
+            case EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT -> GENERAL;
+            case EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT -> VALIDATION;
+            case EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT -> PERFORMANCE;
+            default -> throw new RuntimeException("Bits are either a combination of bits or invalid");
+        };
+    }
+}

--- a/src/main/java/me/hydos/rosella/debug/VulkanDebugCallback.java
+++ b/src/main/java/me/hydos/rosella/debug/VulkanDebugCallback.java
@@ -1,0 +1,93 @@
+package me.hydos.rosella.debug;
+
+import org.jetbrains.annotations.NotNull;
+import org.lwjgl.vulkan.VK10;
+import org.lwjgl.vulkan.VkDebugUtilsMessengerCallbackDataEXT;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class VulkanDebugCallback {
+
+    private final Set<Callback> callbacks = new ConcurrentSkipListSet<>();
+
+    public VulkanDebugCallback() {
+    }
+
+    public void registerCallback(Callback cb) {
+        this.callbacks.add(cb);
+    }
+
+    public void removeCallback(Callback cb) {
+        this.callbacks.remove(cb);
+    }
+
+    public void destroy() {
+        // The callback is registered during instance creation so we dont have to destroy anything
+    }
+
+    public int vulkanCallbackFunction(int severityBits, int typeBits, long pCallbackData, long pUserData) {
+        try {
+            VkDebugUtilsMessengerCallbackDataEXT callbackData = VkDebugUtilsMessengerCallbackDataEXT.create(pCallbackData);
+            MessageSeverity severity = MessageSeverity.fromBits(severityBits);
+            MessageType type = MessageType.fromBits(typeBits);
+
+            callbacks.forEach(cb -> cb.call(severity, type, callbackData));
+
+        } catch (Exception ex) {
+            // TODO log?
+        }
+        return VK10.VK_FALSE;
+    }
+
+    public static abstract class Callback implements Comparable<Callback> {
+        // Needed as a value to compare to for the skip list
+        private static final AtomicInteger _nextId = new AtomicInteger(1);
+        private final int _id;
+
+        protected final AtomicInteger severityMask;
+        protected final AtomicInteger typeMask;
+
+        protected Callback(int severityMask, int typeMask) {
+            this._id = _nextId.getAndIncrement();
+
+            this.severityMask = new AtomicInteger(severityMask);
+            this.typeMask = new AtomicInteger(typeMask);
+        }
+
+        public void call(MessageSeverity severity, MessageType type, VkDebugUtilsMessengerCallbackDataEXT data) {
+            if(severity.isInMask(this.severityMask.get()) && type.isInMask(this.typeMask.get())) {
+                this.callInternal(severity, type, data);
+            }
+        }
+
+        /**
+         * Function that is internally called if the defined severity and type filter matches.
+         *
+         * @param severity The severity of the message
+         * @param type The type of the message
+         * @param data The message
+         */
+        protected abstract void callInternal(MessageSeverity severity, MessageType type, VkDebugUtilsMessengerCallbackDataEXT data);
+
+        @Override
+        public final boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Callback callback = (Callback) o;
+            return _id == callback._id;
+        }
+
+        @Override
+        public final int hashCode() {
+            return Objects.hash(_id);
+        }
+
+        @Override
+        public final int compareTo(@NotNull Callback other) {
+            return this._id - other._id;
+        }
+    }
+}

--- a/src/main/java/me/hydos/rosella/device/LegacyVulkanDevice.java
+++ b/src/main/java/me/hydos/rosella/device/LegacyVulkanDevice.java
@@ -1,0 +1,294 @@
+package me.hydos.rosella.device;
+
+import me.hydos.rosella.render.swapchain.Swapchain;
+import me.hydos.rosella.render.swapchain.SwapchainSupportDetails;
+import me.hydos.rosella.util.VkUtils;
+import me.hydos.rosella.vkobjects.VkCommon;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.*;
+
+import java.nio.IntBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static me.hydos.rosella.memory.Memory.asPtrBuffer;
+import static me.hydos.rosella.util.VkUtils.ok;
+import static org.lwjgl.vulkan.KHRSwapchain.VK_KHR_SWAPCHAIN_EXTENSION_NAME;
+import static org.lwjgl.vulkan.VK10.*;
+
+/**
+ * The object which represents both a Physical and Logical device used by {@link me.hydos.rosella.Rosella}
+ */
+public class LegacyVulkanDevice {
+
+    private static final Set<String> REQUIRED_EXTENSIONS = Collections.singleton(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+
+    public final QueueFamilyIndices indices;
+    public VkDevice rawDevice;
+    public VkPhysicalDevice physicalDevice;
+    public DeviceFeatures deviceFeatures;
+    public Properties properties;
+    public String combinedExtensionsString;
+
+    /**
+     * @param common           the vulkan common variables
+     * @param validationLayers the validation layers to use
+     * @deprecated Use the other method to allow for more than just anisotropy
+     */
+    @Deprecated
+    public LegacyVulkanDevice(VkCommon common, List<String> validationLayers) {
+        this(common, validationLayers, deviceFeatures -> deviceFeatures
+                .samplerAnisotropy(true)
+                .depthClamp(true)
+                .depthBounds(true));
+    }
+
+    public LegacyVulkanDevice(VkCommon common, List<String> validationLayers, Consumer<VkPhysicalDeviceFeatures> deviceFeatureCallback) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer pPhysicalDeviceCount = stack.ints(0);
+            ok(vkEnumeratePhysicalDevices(common.vkInstance.rawInstance, pPhysicalDeviceCount, null));
+            // Unless the user is somehow hot swapping gpu's while the engine is running, this is 100% safe to do.
+            if (pPhysicalDeviceCount.get(0) == 0) {
+                throw new RuntimeException("Your system does not have vulkan support. Make sure your drivers are up to date.");
+            }
+
+            // Retrieve the VkPhysicalDevice
+            PointerBuffer pPhysicalDevices = stack.mallocPointer(pPhysicalDeviceCount.get(0));
+            ok(vkEnumeratePhysicalDevices(common.vkInstance.rawInstance, pPhysicalDeviceCount, pPhysicalDevices));
+
+            for (int i = 0; i < pPhysicalDeviceCount.capacity(); i++) {
+                VkPhysicalDevice device = new VkPhysicalDevice(pPhysicalDevices.get(i), common.vkInstance.rawInstance);
+                Set<String> supportedExtensions = getExtensionStrings(device);
+
+                if (deviceSuitable(device, common, supportedExtensions)) {
+                    // FIXME this doesn't work if there are multiple gpus in the system, ex integrated and pcie
+                    this.physicalDevice = device;
+                    StringBuilder stringBuilder = new StringBuilder();
+                    for (String extension : supportedExtensions) {
+                        stringBuilder.append(extension).append(" ");
+                    }
+                    stringBuilder.deleteCharAt(stringBuilder.length() - 1); // remove extra space
+                    this.combinedExtensionsString = stringBuilder.toString();
+                    setDeviceInfo();
+                    break;
+                }
+            }
+
+            // Create a VkLogicalDevice
+            this.indices = VkUtils.findQueueFamilies(physicalDevice, common.surface);
+            int[] uniqueQueueFamilies = indices.unique();
+            VkDeviceQueueCreateInfo.Buffer queueCreateInfos = VkDeviceQueueCreateInfo.callocStack(uniqueQueueFamilies.length, stack);
+
+            for (int i = 0; i < uniqueQueueFamilies.length; i++) {
+                queueCreateInfos.get(i)
+                        .sType(VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO)
+                        .queueFamilyIndex(uniqueQueueFamilies[i])
+                        .pQueuePriorities(stack.floats(1.0f));
+            }
+
+            VkPhysicalDeviceFeatures deviceFeatures = VkPhysicalDeviceFeatures.callocStack(stack);
+            deviceFeatureCallback.accept(deviceFeatures);
+
+            VkDeviceCreateInfo deviceCreateInfo = VkDeviceCreateInfo.callocStack(stack)
+                    .sType(VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO)
+                    .pQueueCreateInfos(queueCreateInfos)
+                    .pEnabledFeatures(deviceFeatures)
+                    .ppEnabledExtensionNames(asPtrBuffer(REQUIRED_EXTENSIONS));
+
+            if (validationLayers.size() != 0) {
+                deviceCreateInfo.ppEnabledLayerNames(asPtrBuffer(validationLayers));
+            }
+
+            PointerBuffer pDevice = stack.pointers(VK_NULL_HANDLE);
+            ok(vkCreateDevice(physicalDevice, deviceCreateInfo, null, pDevice));
+            rawDevice = new VkDevice(pDevice.get(0), physicalDevice, deviceCreateInfo);
+        }
+    }
+
+    private void setDeviceInfo() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            VkPhysicalDeviceProperties properties = VkPhysicalDeviceProperties.callocStack(stack);
+            vkGetPhysicalDeviceProperties(physicalDevice, properties);
+
+            this.properties = new Properties(properties);
+        }
+    }
+
+    /**
+     * Waits for the underlying device which this Vulkan instance is operating on to be idle
+     */
+    public void waitForIdle() {
+        ok(vkDeviceWaitIdle(rawDevice));
+    }
+
+    /**
+     * Checks if a device is suitable enough for our use.
+     *
+     * @param device the {@link VkPhysicalDevice} to test
+     * @param common the Rosella shared fields
+     * @return if the physical device can be used
+     */
+    private boolean deviceSuitable(VkPhysicalDevice device, VkCommon common, Set<String> supportedExtensions) {
+        QueueFamilyIndices indices = VkUtils.findQueueFamilies(device, common.surface);
+
+        if (supportedExtensions.containsAll(REQUIRED_EXTENSIONS)) {
+            try (MemoryStack stack = MemoryStack.stackPush()) {
+                boolean swapChainAdequate;
+                boolean anisotropySupported;
+
+                SwapchainSupportDetails swapchainSupport = Swapchain.Companion.querySwapchainSupport(device, stack, common.surface); // TODO: unkotlinify the swapchain
+                swapChainAdequate = swapchainSupport.formats.hasRemaining() && swapchainSupport.presentModes.hasRemaining(); // Check if the swapchain has valid formats and present modes available
+                VkPhysicalDeviceFeatures supportedFeatures = VkPhysicalDeviceFeatures.callocStack(stack);
+                vkGetPhysicalDeviceFeatures(device, supportedFeatures);
+                this.deviceFeatures = getFeatures(supportedFeatures);
+                anisotropySupported = supportedFeatures.samplerAnisotropy();
+
+                return indices.isComplete() && swapChainAdequate && anisotropySupported;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Copies all of the features out of {@link VkPhysicalDeviceFeatures} so it can be read later on when the stack is freed.
+     *
+     * @param supportedFeatures the Vulkan struct
+     * @return a usable class
+     */
+    private DeviceFeatures getFeatures(VkPhysicalDeviceFeatures supportedFeatures) {
+        return new DeviceFeatures(
+                supportedFeatures.robustBufferAccess(),
+                supportedFeatures.fullDrawIndexUint32(),
+                supportedFeatures.imageCubeArray(),
+                supportedFeatures.independentBlend(),
+                supportedFeatures.geometryShader(),
+                supportedFeatures.tessellationShader(),
+                supportedFeatures.sampleRateShading(),
+                supportedFeatures.dualSrcBlend(),
+                supportedFeatures.logicOp(),
+                supportedFeatures.multiDrawIndirect(),
+                supportedFeatures.drawIndirectFirstInstance(),
+                supportedFeatures.depthClamp(),
+                supportedFeatures.depthBiasClamp(),
+                supportedFeatures.fillModeNonSolid(),
+                supportedFeatures.depthBounds(),
+                supportedFeatures.wideLines(),
+                supportedFeatures.largePoints(),
+                supportedFeatures.alphaToOne(),
+                supportedFeatures.multiViewport(),
+                supportedFeatures.samplerAnisotropy(),
+                supportedFeatures.textureCompressionETC2(),
+                supportedFeatures.textureCompressionASTC_LDR(),
+                supportedFeatures.textureCompressionBC(),
+                supportedFeatures.occlusionQueryPrecise(),
+                supportedFeatures.pipelineStatisticsQuery(),
+                supportedFeatures.vertexPipelineStoresAndAtomics(),
+                supportedFeatures.fragmentStoresAndAtomics(),
+                supportedFeatures.shaderTessellationAndGeometryPointSize(),
+                supportedFeatures.shaderImageGatherExtended(),
+                supportedFeatures.shaderStorageImageExtendedFormats(),
+                supportedFeatures.shaderStorageImageMultisample(),
+                supportedFeatures.shaderStorageImageReadWithoutFormat(),
+                supportedFeatures.shaderStorageImageWriteWithoutFormat(),
+                supportedFeatures.shaderUniformBufferArrayDynamicIndexing(),
+                supportedFeatures.shaderSampledImageArrayDynamicIndexing(),
+                supportedFeatures.shaderStorageBufferArrayDynamicIndexing(),
+                supportedFeatures.shaderStorageImageArrayDynamicIndexing(),
+                supportedFeatures.shaderClipDistance(),
+                supportedFeatures.shaderCullDistance(),
+                supportedFeatures.shaderFloat64(),
+                supportedFeatures.shaderInt64(),
+                supportedFeatures.shaderInt16(),
+                supportedFeatures.shaderResourceResidency(),
+                supportedFeatures.shaderResourceMinLod(),
+                supportedFeatures.sparseBinding(),
+                supportedFeatures.sparseResidencyBuffer(),
+                supportedFeatures.sparseResidencyImage2D(),
+                supportedFeatures.sparseResidencyImage3D(),
+                supportedFeatures.sparseResidency2Samples(),
+                supportedFeatures.sparseResidency4Samples(),
+                supportedFeatures.sparseResidency8Samples(),
+                supportedFeatures.sparseResidency16Samples(),
+                supportedFeatures.sparseResidencyAliased(),
+                supportedFeatures.variableMultisampleRate(),
+                supportedFeatures.inheritedQueries());
+    }
+
+    /**
+     * @param device the device to check
+     * @return all of the supported extensions of the device as a set of strings.
+     */
+    private Set<String> getExtensionStrings(VkPhysicalDevice device) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer extensionCount = stack.ints(0);
+            ok(vkEnumerateDeviceExtensionProperties(device, (CharSequence) null, extensionCount, null));
+            VkExtensionProperties.Buffer availableExtensions = VkExtensionProperties.callocStack(extensionCount.get(0), stack);
+            ok(vkEnumerateDeviceExtensionProperties(device, (CharSequence) null, extensionCount, availableExtensions));
+            return availableExtensions.stream()
+                    .map(VkExtensionProperties::extensionNameString)
+                    .collect(Collectors.toSet());
+        }
+    }
+
+    public record DeviceFeatures(boolean robustBufferAccess, boolean fullDrawIndexUint32, boolean imageCubeArray,
+                                 boolean independentBlend, boolean geometryShader, boolean tessellationShader,
+                                 boolean sampleRateShading, boolean dualSrcBlend, boolean logicOp,
+                                 boolean multiDrawIndirect, boolean drawIndirectFirstInstance, boolean depthClamp,
+                                 boolean depthBiasClamp, boolean fillModeNonSolid, boolean depthBounds,
+                                 boolean wideLines,
+                                 boolean largePoints, boolean alphaToOne, boolean multiViewport,
+                                 boolean samplerAnisotropy,
+                                 boolean textureCompressionETC2, boolean textureCompressionASTC_LDR,
+                                 boolean textureCompressionBC, boolean occlusionQueryPrecise,
+                                 boolean pipelineStatisticsQuery, boolean vertexPipelineStoresAndAtomics,
+                                 boolean fragmentStoresAndAtomics, boolean shaderTessellationAndGeometryPointSize,
+                                 boolean shaderImageGatherExtended, boolean shaderStorageImageExtendedFormats,
+                                 boolean shaderStorageImageMultisample, boolean shaderStorageImageReadWithoutFormat,
+                                 boolean shaderStorageImageWriteWithoutFormat,
+                                 boolean shaderUniformBufferArrayDynamicIndexing,
+                                 boolean shaderSampledImageArrayDynamicIndexing,
+                                 boolean shaderStorageBufferArrayDynamicIndexing,
+                                 boolean shaderStorageImageArrayDynamicIndexing, boolean shaderClipDistance,
+                                 boolean shaderCullDistance, boolean shaderFloat64, boolean shaderInt64,
+                                 boolean shaderInt16, boolean shaderResourceResidency, boolean shaderResourceMinLod,
+                                 boolean sparseBinding, boolean sparseResidencyBuffer, boolean sparseResidencyImage2D,
+                                 boolean sparseResidencyImage3D, boolean sparseResidency2Samples,
+                                 boolean sparseResidency4Samples, boolean sparseResidency8Samples,
+                                 boolean sparseResidency16Samples, boolean sparseResidencyAliased,
+                                 boolean variableMultisampleRate, boolean inheritedQueries) {
+    }
+
+    public static class Properties {
+
+        public final int deviceId;
+        public final String deviceName;
+        public final String apiVersion;
+        public final int driverVersion;
+        public final int vendorId;
+
+        public Properties(VkPhysicalDeviceProperties properties) {
+            this.deviceId = properties.deviceID();
+            this.deviceName = properties.deviceNameString();
+            this.apiVersion = fromVkVersion(properties.apiVersion());
+            this.driverVersion = properties.driverVersion();
+            this.vendorId = properties.vendorID();
+        }
+
+        /**
+         * Turns integer VkVersion into a string version
+         *
+         * @param apiVersion the integer passed from vulkan
+         * @return a readable string
+         */
+        private String fromVkVersion(int apiVersion) {
+            int major = VK_VERSION_MAJOR(apiVersion);
+            int minor = VK_VERSION_MINOR(apiVersion);
+            int patch = VK_VERSION_PATCH(apiVersion);
+            return major + "." + minor + "." + patch;
+        }
+    }
+}

--- a/src/main/java/me/hydos/rosella/device/LegacyVulkanDevice.java
+++ b/src/main/java/me/hydos/rosella/device/LegacyVulkanDevice.java
@@ -23,6 +23,7 @@ import static org.lwjgl.vulkan.VK10.*;
 /**
  * The object which represents both a Physical and Logical device used by {@link me.hydos.rosella.Rosella}
  */
+@Deprecated
 public class LegacyVulkanDevice {
 
     private static final Set<String> REQUIRED_EXTENSIONS = Collections.singleton(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
@@ -39,7 +40,6 @@ public class LegacyVulkanDevice {
      * @param validationLayers the validation layers to use
      * @deprecated Use the other method to allow for more than just anisotropy
      */
-    @Deprecated
     public LegacyVulkanDevice(VkCommon common, List<String> validationLayers) {
         this(common, validationLayers, deviceFeatures -> deviceFeatures
                 .samplerAnisotropy(true)

--- a/src/main/java/me/hydos/rosella/device/LegacyVulkanDevice.java
+++ b/src/main/java/me/hydos/rosella/device/LegacyVulkanDevice.java
@@ -38,6 +38,13 @@ public class LegacyVulkanDevice {
     public VkDevice rawDevice;
     public VkPhysicalDevice physicalDevice;
 
+    public LegacyVulkanDevice(VulkanDevice device) {
+        this.newDevice = device;
+        this.indices = RosellaLegacy.getMetaObject(device.getFeatureMeta(RosellaLegacy.NAME)).indices();
+        this.rawDevice = device.getDevice();
+        this.physicalDevice = device.getDevice().getPhysicalDevice();
+    }
+
     public LegacyVulkanDevice(VulkanInstance instance, InitializationRegistry registry) {
         DeviceBuilder builder = new DeviceBuilder(instance, registry);
         this.newDevice = builder.build();

--- a/src/main/java/me/hydos/rosella/device/LegacyVulkanDevice.java
+++ b/src/main/java/me/hydos/rosella/device/LegacyVulkanDevice.java
@@ -40,7 +40,7 @@ public class LegacyVulkanDevice {
 
     public LegacyVulkanDevice(VulkanDevice device) {
         this.newDevice = device;
-        this.indices = RosellaLegacy.getMetaObject(device.getFeatureMeta(RosellaLegacy.NAME)).indices();
+        this.indices = RosellaLegacy.getMetadata(device).indices();
         this.rawDevice = device.getDevice();
         this.physicalDevice = device.getDevice().getPhysicalDevice();
     }
@@ -49,7 +49,7 @@ public class LegacyVulkanDevice {
         DeviceBuilder builder = new DeviceBuilder(instance, registry);
         this.newDevice = builder.build();
 
-        this.indices = RosellaLegacy.getMetaObject(this.newDevice.getFeatureMeta(RosellaLegacy.NAME)).indices();
+        this.indices = RosellaLegacy.getMetadata(this.newDevice).indices();
         this.rawDevice = this.newDevice.getDevice();
         this.physicalDevice = this.rawDevice.getPhysicalDevice();
     }

--- a/src/main/java/me/hydos/rosella/device/VulkanDevice.java
+++ b/src/main/java/me/hydos/rosella/device/VulkanDevice.java
@@ -1,5 +1,6 @@
 package me.hydos.rosella.device;
 
+import me.hydos.rosella.util.NamedID;
 import org.lwjgl.vulkan.VK10;
 import org.lwjgl.vulkan.VkDevice;
 
@@ -9,9 +10,9 @@ import java.util.Map;
 public class VulkanDevice {
 
     private final VkDevice device;
-    private final Map<String, Object> enableFeatures;
+    private final Map<NamedID, Object> enableFeatures;
 
-    public VulkanDevice(VkDevice device, Map<String, Object> enabledFeatures) {
+    public VulkanDevice(VkDevice device, Map<NamedID, Object> enabledFeatures) {
         this.device = device;
         this.enableFeatures = Collections.unmodifiableMap(enabledFeatures);
     }
@@ -30,7 +31,7 @@ public class VulkanDevice {
      * @param name The name of the feature.
      * @return True if the feature is enabled. False otherwise.
      */
-    public boolean isFeatureEnabled(String name) {
+    public boolean isFeatureEnabled(NamedID name) {
         return enableFeatures.containsKey(name);
     }
 
@@ -40,7 +41,7 @@ public class VulkanDevice {
      * @param name The name of the feature.
      * @return The metadata for the feature or null if the feature didnt generate any metadata.
      */
-    public Object getFeatureMeta(String name) {
+    public Object getFeatureMeta(NamedID name) {
         return enableFeatures.get(name);
     }
 }

--- a/src/main/java/me/hydos/rosella/device/VulkanDevice.java
+++ b/src/main/java/me/hydos/rosella/device/VulkanDevice.java
@@ -1,294 +1,41 @@
 package me.hydos.rosella.device;
 
-import me.hydos.rosella.render.swapchain.Swapchain;
-import me.hydos.rosella.render.swapchain.SwapchainSupportDetails;
-import me.hydos.rosella.util.VkUtils;
-import me.hydos.rosella.vkobjects.VkCommon;
-import org.lwjgl.PointerBuffer;
-import org.lwjgl.system.MemoryStack;
-import org.lwjgl.vulkan.*;
+import org.lwjgl.vulkan.VkDevice;
 
-import java.nio.IntBuffer;
 import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import java.util.Map;
 
-import static me.hydos.rosella.memory.Memory.asPtrBuffer;
-import static me.hydos.rosella.util.VkUtils.ok;
-import static org.lwjgl.vulkan.KHRSwapchain.VK_KHR_SWAPCHAIN_EXTENSION_NAME;
-import static org.lwjgl.vulkan.VK10.*;
-
-/**
- * The object which represents both a Physical and Logical device used by {@link me.hydos.rosella.Rosella}
- */
 public class VulkanDevice {
 
-    private static final Set<String> REQUIRED_EXTENSIONS = Collections.singleton(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+    private final VkDevice device;
+    private final Map<String, Object> enableFeatures;
 
-    public final QueueFamilyIndices indices;
-    public VkDevice rawDevice;
-    public VkPhysicalDevice physicalDevice;
-    public DeviceFeatures deviceFeatures;
-    public Properties properties;
-    public String combinedExtensionsString;
-
-    /**
-     * @param common           the vulkan common variables
-     * @param validationLayers the validation layers to use
-     * @deprecated Use the other method to allow for more than just anisotropy
-     */
-    @Deprecated
-    public VulkanDevice(VkCommon common, List<String> validationLayers) {
-        this(common, validationLayers, deviceFeatures -> deviceFeatures
-                .samplerAnisotropy(true)
-                .depthClamp(true)
-                .depthBounds(true));
+    public VulkanDevice(VkDevice device, Map<String, Object> enabledFeatures) {
+        this.device = device;
+        this.enableFeatures = Collections.unmodifiableMap(enabledFeatures);
     }
 
-    public VulkanDevice(VkCommon common, List<String> validationLayers, Consumer<VkPhysicalDeviceFeatures> deviceFeatureCallback) {
-        try (MemoryStack stack = MemoryStack.stackPush()) {
-            IntBuffer pPhysicalDeviceCount = stack.ints(0);
-            ok(vkEnumeratePhysicalDevices(common.vkInstance.rawInstance, pPhysicalDeviceCount, null));
-            // Unless the user is somehow hot swapping gpu's while the engine is running, this is 100% safe to do.
-            if (pPhysicalDeviceCount.get(0) == 0) {
-                throw new RuntimeException("Your system does not have vulkan support. Make sure your drivers are up to date.");
-            }
-
-            // Retrieve the VkPhysicalDevice
-            PointerBuffer pPhysicalDevices = stack.mallocPointer(pPhysicalDeviceCount.get(0));
-            ok(vkEnumeratePhysicalDevices(common.vkInstance.rawInstance, pPhysicalDeviceCount, pPhysicalDevices));
-
-            for (int i = 0; i < pPhysicalDeviceCount.capacity(); i++) {
-                VkPhysicalDevice device = new VkPhysicalDevice(pPhysicalDevices.get(i), common.vkInstance.rawInstance);
-                Set<String> supportedExtensions = getExtensionStrings(device);
-
-                if (deviceSuitable(device, common, supportedExtensions)) {
-                    // FIXME this doesn't work if there are multiple gpus in the system, ex integrated and pcie
-                    this.physicalDevice = device;
-                    StringBuilder stringBuilder = new StringBuilder();
-                    for (String extension : supportedExtensions) {
-                        stringBuilder.append(extension).append(" ");
-                    }
-                    stringBuilder.deleteCharAt(stringBuilder.length() - 1); // remove extra space
-                    this.combinedExtensionsString = stringBuilder.toString();
-                    setDeviceInfo();
-                    break;
-                }
-            }
-
-            // Create a VkLogicalDevice
-            this.indices = VkUtils.findQueueFamilies(physicalDevice, common.surface);
-            int[] uniqueQueueFamilies = indices.unique();
-            VkDeviceQueueCreateInfo.Buffer queueCreateInfos = VkDeviceQueueCreateInfo.callocStack(uniqueQueueFamilies.length, stack);
-
-            for (int i = 0; i < uniqueQueueFamilies.length; i++) {
-                queueCreateInfos.get(i)
-                        .sType(VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO)
-                        .queueFamilyIndex(uniqueQueueFamilies[i])
-                        .pQueuePriorities(stack.floats(1.0f));
-            }
-
-            VkPhysicalDeviceFeatures deviceFeatures = VkPhysicalDeviceFeatures.callocStack(stack);
-            deviceFeatureCallback.accept(deviceFeatures);
-
-            VkDeviceCreateInfo deviceCreateInfo = VkDeviceCreateInfo.callocStack(stack)
-                    .sType(VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO)
-                    .pQueueCreateInfos(queueCreateInfos)
-                    .pEnabledFeatures(deviceFeatures)
-                    .ppEnabledExtensionNames(asPtrBuffer(REQUIRED_EXTENSIONS));
-
-            if (validationLayers.size() != 0) {
-                deviceCreateInfo.ppEnabledLayerNames(asPtrBuffer(validationLayers));
-            }
-
-            PointerBuffer pDevice = stack.pointers(VK_NULL_HANDLE);
-            ok(vkCreateDevice(physicalDevice, deviceCreateInfo, null, pDevice));
-            rawDevice = new VkDevice(pDevice.get(0), physicalDevice, deviceCreateInfo);
-        }
-    }
-
-    private void setDeviceInfo() {
-        try (MemoryStack stack = MemoryStack.stackPush()) {
-            VkPhysicalDeviceProperties properties = VkPhysicalDeviceProperties.callocStack(stack);
-            vkGetPhysicalDeviceProperties(physicalDevice, properties);
-
-            this.properties = new Properties(properties);
-        }
+    public VkDevice getDevice() {
+        return this.device;
     }
 
     /**
-     * Waits for the underlying device which this Vulkan instance is operating on to be idle
-     */
-    public void waitForIdle() {
-        ok(vkDeviceWaitIdle(rawDevice));
-    }
-
-    /**
-     * Checks if a device is suitable enough for our use.
+     * Tests if a ApplicationFeature is enabled for this device.
      *
-     * @param device the {@link VkPhysicalDevice} to test
-     * @param common the Rosella shared fields
-     * @return if the physical device can be used
+     * @param name The name of the feature.
+     * @return True if the feature is enabled. False otherwise.
      */
-    private boolean deviceSuitable(VkPhysicalDevice device, VkCommon common, Set<String> supportedExtensions) {
-        QueueFamilyIndices indices = VkUtils.findQueueFamilies(device, common.surface);
-
-        if (supportedExtensions.containsAll(REQUIRED_EXTENSIONS)) {
-            try (MemoryStack stack = MemoryStack.stackPush()) {
-                boolean swapChainAdequate;
-                boolean anisotropySupported;
-
-                SwapchainSupportDetails swapchainSupport = Swapchain.Companion.querySwapchainSupport(device, stack, common.surface); // TODO: unkotlinify the swapchain
-                swapChainAdequate = swapchainSupport.formats.hasRemaining() && swapchainSupport.presentModes.hasRemaining(); // Check if the swapchain has valid formats and present modes available
-                VkPhysicalDeviceFeatures supportedFeatures = VkPhysicalDeviceFeatures.callocStack(stack);
-                vkGetPhysicalDeviceFeatures(device, supportedFeatures);
-                this.deviceFeatures = getFeatures(supportedFeatures);
-                anisotropySupported = supportedFeatures.samplerAnisotropy();
-
-                return indices.isComplete() && swapChainAdequate && anisotropySupported;
-            }
-        }
-        return false;
+    public boolean isFeatureEnabled(String name) {
+        return enableFeatures.containsKey(name);
     }
 
     /**
-     * Copies all of the features out of {@link VkPhysicalDeviceFeatures} so it can be read later on when the stack is freed.
+     * Retrieves the metadata for an enabled ApplicationFeature.
      *
-     * @param supportedFeatures the Vulkan struct
-     * @return a usable class
+     * @param name The name of the feature.
+     * @return The metadata for the feature or null if the feature didnt generate any metadata.
      */
-    private DeviceFeatures getFeatures(VkPhysicalDeviceFeatures supportedFeatures) {
-        return new DeviceFeatures(
-                supportedFeatures.robustBufferAccess(),
-                supportedFeatures.fullDrawIndexUint32(),
-                supportedFeatures.imageCubeArray(),
-                supportedFeatures.independentBlend(),
-                supportedFeatures.geometryShader(),
-                supportedFeatures.tessellationShader(),
-                supportedFeatures.sampleRateShading(),
-                supportedFeatures.dualSrcBlend(),
-                supportedFeatures.logicOp(),
-                supportedFeatures.multiDrawIndirect(),
-                supportedFeatures.drawIndirectFirstInstance(),
-                supportedFeatures.depthClamp(),
-                supportedFeatures.depthBiasClamp(),
-                supportedFeatures.fillModeNonSolid(),
-                supportedFeatures.depthBounds(),
-                supportedFeatures.wideLines(),
-                supportedFeatures.largePoints(),
-                supportedFeatures.alphaToOne(),
-                supportedFeatures.multiViewport(),
-                supportedFeatures.samplerAnisotropy(),
-                supportedFeatures.textureCompressionETC2(),
-                supportedFeatures.textureCompressionASTC_LDR(),
-                supportedFeatures.textureCompressionBC(),
-                supportedFeatures.occlusionQueryPrecise(),
-                supportedFeatures.pipelineStatisticsQuery(),
-                supportedFeatures.vertexPipelineStoresAndAtomics(),
-                supportedFeatures.fragmentStoresAndAtomics(),
-                supportedFeatures.shaderTessellationAndGeometryPointSize(),
-                supportedFeatures.shaderImageGatherExtended(),
-                supportedFeatures.shaderStorageImageExtendedFormats(),
-                supportedFeatures.shaderStorageImageMultisample(),
-                supportedFeatures.shaderStorageImageReadWithoutFormat(),
-                supportedFeatures.shaderStorageImageWriteWithoutFormat(),
-                supportedFeatures.shaderUniformBufferArrayDynamicIndexing(),
-                supportedFeatures.shaderSampledImageArrayDynamicIndexing(),
-                supportedFeatures.shaderStorageBufferArrayDynamicIndexing(),
-                supportedFeatures.shaderStorageImageArrayDynamicIndexing(),
-                supportedFeatures.shaderClipDistance(),
-                supportedFeatures.shaderCullDistance(),
-                supportedFeatures.shaderFloat64(),
-                supportedFeatures.shaderInt64(),
-                supportedFeatures.shaderInt16(),
-                supportedFeatures.shaderResourceResidency(),
-                supportedFeatures.shaderResourceMinLod(),
-                supportedFeatures.sparseBinding(),
-                supportedFeatures.sparseResidencyBuffer(),
-                supportedFeatures.sparseResidencyImage2D(),
-                supportedFeatures.sparseResidencyImage3D(),
-                supportedFeatures.sparseResidency2Samples(),
-                supportedFeatures.sparseResidency4Samples(),
-                supportedFeatures.sparseResidency8Samples(),
-                supportedFeatures.sparseResidency16Samples(),
-                supportedFeatures.sparseResidencyAliased(),
-                supportedFeatures.variableMultisampleRate(),
-                supportedFeatures.inheritedQueries());
-    }
-
-    /**
-     * @param device the device to check
-     * @return all of the supported extensions of the device as a set of strings.
-     */
-    private Set<String> getExtensionStrings(VkPhysicalDevice device) {
-        try (MemoryStack stack = MemoryStack.stackPush()) {
-            IntBuffer extensionCount = stack.ints(0);
-            ok(vkEnumerateDeviceExtensionProperties(device, (CharSequence) null, extensionCount, null));
-            VkExtensionProperties.Buffer availableExtensions = VkExtensionProperties.callocStack(extensionCount.get(0), stack);
-            ok(vkEnumerateDeviceExtensionProperties(device, (CharSequence) null, extensionCount, availableExtensions));
-            return availableExtensions.stream()
-                    .map(VkExtensionProperties::extensionNameString)
-                    .collect(Collectors.toSet());
-        }
-    }
-
-    public record DeviceFeatures(boolean robustBufferAccess, boolean fullDrawIndexUint32, boolean imageCubeArray,
-                                 boolean independentBlend, boolean geometryShader, boolean tessellationShader,
-                                 boolean sampleRateShading, boolean dualSrcBlend, boolean logicOp,
-                                 boolean multiDrawIndirect, boolean drawIndirectFirstInstance, boolean depthClamp,
-                                 boolean depthBiasClamp, boolean fillModeNonSolid, boolean depthBounds,
-                                 boolean wideLines,
-                                 boolean largePoints, boolean alphaToOne, boolean multiViewport,
-                                 boolean samplerAnisotropy,
-                                 boolean textureCompressionETC2, boolean textureCompressionASTC_LDR,
-                                 boolean textureCompressionBC, boolean occlusionQueryPrecise,
-                                 boolean pipelineStatisticsQuery, boolean vertexPipelineStoresAndAtomics,
-                                 boolean fragmentStoresAndAtomics, boolean shaderTessellationAndGeometryPointSize,
-                                 boolean shaderImageGatherExtended, boolean shaderStorageImageExtendedFormats,
-                                 boolean shaderStorageImageMultisample, boolean shaderStorageImageReadWithoutFormat,
-                                 boolean shaderStorageImageWriteWithoutFormat,
-                                 boolean shaderUniformBufferArrayDynamicIndexing,
-                                 boolean shaderSampledImageArrayDynamicIndexing,
-                                 boolean shaderStorageBufferArrayDynamicIndexing,
-                                 boolean shaderStorageImageArrayDynamicIndexing, boolean shaderClipDistance,
-                                 boolean shaderCullDistance, boolean shaderFloat64, boolean shaderInt64,
-                                 boolean shaderInt16, boolean shaderResourceResidency, boolean shaderResourceMinLod,
-                                 boolean sparseBinding, boolean sparseResidencyBuffer, boolean sparseResidencyImage2D,
-                                 boolean sparseResidencyImage3D, boolean sparseResidency2Samples,
-                                 boolean sparseResidency4Samples, boolean sparseResidency8Samples,
-                                 boolean sparseResidency16Samples, boolean sparseResidencyAliased,
-                                 boolean variableMultisampleRate, boolean inheritedQueries) {
-    }
-
-    public static class Properties {
-
-        public final int deviceId;
-        public final String deviceName;
-        public final String apiVersion;
-        public final int driverVersion;
-        public final int vendorId;
-
-        public Properties(VkPhysicalDeviceProperties properties) {
-            this.deviceId = properties.deviceID();
-            this.deviceName = properties.deviceNameString();
-            this.apiVersion = fromVkVersion(properties.apiVersion());
-            this.driverVersion = properties.driverVersion();
-            this.vendorId = properties.vendorID();
-        }
-
-        /**
-         * Turns integer VkVersion into a string version
-         *
-         * @param apiVersion the integer passed from vulkan
-         * @return a readable string
-         */
-        private String fromVkVersion(int apiVersion) {
-            int major = VK_VERSION_MAJOR(apiVersion);
-            int minor = VK_VERSION_MINOR(apiVersion);
-            int patch = VK_VERSION_PATCH(apiVersion);
-            return major + "." + minor + "." + patch;
-        }
+    public Object getFeatureMeta(String name) {
+        return enableFeatures.get(name);
     }
 }

--- a/src/main/java/me/hydos/rosella/device/VulkanDevice.java
+++ b/src/main/java/me/hydos/rosella/device/VulkanDevice.java
@@ -1,5 +1,6 @@
 package me.hydos.rosella.device;
 
+import org.lwjgl.vulkan.VK10;
 import org.lwjgl.vulkan.VkDevice;
 
 import java.util.Collections;
@@ -17,6 +18,10 @@ public class VulkanDevice {
 
     public VkDevice getDevice() {
         return this.device;
+    }
+
+    public void destroy() {
+        VK10.vkDestroyDevice(this.device, null);
     }
 
     /**

--- a/src/main/java/me/hydos/rosella/device/VulkanQueues.java
+++ b/src/main/java/me/hydos/rosella/device/VulkanQueues.java
@@ -16,19 +16,8 @@ public class VulkanQueues {
     public final VulkanQueue graphicsQueue;
     public final VulkanQueue presentQueue;
 
-    public VulkanQueues(VkCommon common) {
-        try (MemoryStack stack = MemoryStack.stackPush()) {
-            PointerBuffer pQueues = stack.pointers(VK_NULL_HANDLE);
-            vkGetDeviceQueue(common.device.rawDevice, common.device.indices.graphicsFamily, 0, pQueues);
-            this.graphicsQueue = new VulkanQueue(new VkQueue((pQueues.get(0)), common.device.rawDevice), common.device.indices.graphicsFamily);
-
-            // Need to make sure that if they are the same queue they are the same object and share the lock
-            if(!common.device.indices.presentFamily.equals(common.device.indices.graphicsFamily)) {
-                vkGetDeviceQueue(common.device.rawDevice, common.device.indices.presentFamily, 0, pQueues);
-                this.presentQueue = new VulkanQueue(new VkQueue((pQueues.get(0)), common.device.rawDevice), common.device.indices.presentFamily);
-            } else {
-                this.presentQueue = this.graphicsQueue;
-            }
-        }
+    public VulkanQueues(VulkanQueue graphicsQueue, VulkanQueue presentQueue) {
+        this.graphicsQueue = graphicsQueue;
+        this.presentQueue = presentQueue;
     }
 }

--- a/src/main/java/me/hydos/rosella/init/ApplicationFeature.java
+++ b/src/main/java/me/hydos/rosella/init/ApplicationFeature.java
@@ -1,0 +1,132 @@
+package me.hydos.rosella.init;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+/**
+ * <p>A class that represents some collection of device features or capabilities.</p>
+ *
+ * <p>Instances of this class can be registered into a {@link me.hydos.rosella.init.InitializationRegistry} which will then be
+ * used to select and initialize a device.</p>
+ *
+ * <p>This happens in 2 stages.
+ * <ol>
+ *     <li>The feature is queried if the device supports the feature.</li>
+ *     <li>If support is detected and desired the feature will be called to configure the device.</li>
+ * </ol>
+ * For these interactions a instance of {@link me.hydos.rosella.init.DeviceBuilder.DeviceMeta} is provided which manages
+ * information for a single physical device.</p>
+ *
+ * <p>Since multiple devices may be tested concurrently the createInstance function will be called for each device which
+ * should return a object that can keep track of all necessary metadata it may need for one device. The ApplicationFeature
+ * class as well as separate created instances may be called concurrently, however created instances individually will
+ * never be called concurrently.</p>
+ *
+ * <p>If the feature wants to return information to the application it can provide a metadata object which will be stored
+ * in the created device for the application to access.</p>
+ *
+ * <p>A feature can access the instances of other features, however it must make sure to declare dependencies as otherwise
+ * those features may not have run yet.</p>
+ *
+ * <p>The default implementation of this class only validates that all dependencies are met and does not create any metadata.</p>
+ */
+public class ApplicationFeature {
+
+    public final String name;
+    public final Set<String> dependencies;
+
+    /**
+     * It is recommended to use the standard minecraft syntax for names. (i.e. "mod:name")
+     *
+     * @param name The name of this feature
+     */
+    public ApplicationFeature(@NotNull String name) {
+        assert(!name.isEmpty());
+        this.name = name;
+        this.dependencies = Collections.emptySet();
+    }
+
+    /**
+     * It is recommended to use the standard minecraft syntax for names. (i.e. "mod:name")
+     *
+     * @param name The name of this feature
+     * @param dependencies A list of dependencies
+     */
+    public ApplicationFeature(@NotNull String name, @Nullable Collection<String> dependencies) {
+        assert(!name.isEmpty());
+        this.name = name;
+        if(dependencies != null) {
+            this.dependencies = Set.copyOf(dependencies);
+        } else {
+            this.dependencies = Collections.emptySet();
+        }
+    }
+
+    /**
+     * @return A new instance to process a device
+     */
+    public Instance createInstance() {
+        return new Instance();
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApplicationFeature that = (ApplicationFeature) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(name);
+    }
+
+    /**
+     * A class to process one device. A instance will never be reused.
+     */
+    public class Instance {
+
+        protected boolean canEnable;
+
+        public final String getFeatureName() {
+            return name;
+        }
+
+        public boolean isSupported() {
+            return this.canEnable;
+        }
+
+        /**
+         * Tests if all dependent features are supported.
+         *
+         * @param meta The DeviceMeta instance.
+         * @return True if all dependant features are supported. False otherwise.
+         */
+        protected boolean allDependenciesMet(DeviceBuilder.DeviceMeta meta) {
+            return dependencies.stream().allMatch(meta::isApplicationFeatureSupported);
+        }
+
+        /**
+         * Tests if the device supports this feature. All dependant features will have had this function called already,
+         * and can be accessed by the DeviceMeta instance provided. This function <b>must</b> set the canEnable boolean.
+         *
+         * @param meta A DeviceMeta instance used to track information about the build process.
+         */
+        public void testFeatureSupport(DeviceBuilder.DeviceMeta meta) {
+            this.canEnable = allDependenciesMet(meta);
+        }
+
+        /**
+         * Should configure the device to enable this feature.
+         *
+         * @param meta A DeviceMeta instance used to track information about the build process.
+         * @return A object that can be used to return information to the application. Can be null.
+         */
+        public Object enableFeature(DeviceBuilder.DeviceMeta meta) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/me/hydos/rosella/init/DeviceBuildConfigurator.java
+++ b/src/main/java/me/hydos/rosella/init/DeviceBuildConfigurator.java
@@ -1,0 +1,32 @@
+package me.hydos.rosella.init;
+
+import me.hydos.rosella.device.VulkanQueue;
+import org.lwjgl.vulkan.VkPhysicalDeviceFeatures;
+
+import java.util.concurrent.Future;
+
+public interface DeviceBuildConfigurator extends DeviceBuildInformation {
+
+    /**
+     * Adds a new queue request
+     *
+     * @param family The family that is requested.
+     * @return A Future which will contain the VulkanQueue after the device has been created.
+     */
+    Future<VulkanQueue> addQueueRequest(int family);
+
+    /**
+     * Adds a extension to the set of enabled extensions. This function does not validate if the extension
+     * is actually supported.
+     *
+     * @param extension The name of the extension.
+     */
+    void enableExtension(String extension);
+
+    /**
+     * Returns an instance that can be used to configure device features.
+     *
+     * @return A VkPhysicalDeviceProperties instance to configure the device.
+     */
+    VkPhysicalDeviceFeatures configureDeviceFeatures();
+}

--- a/src/main/java/me/hydos/rosella/init/DeviceBuildInformation.java
+++ b/src/main/java/me/hydos/rosella/init/DeviceBuildInformation.java
@@ -1,0 +1,61 @@
+package me.hydos.rosella.init;
+
+import me.hydos.rosella.init.features.ApplicationFeature;
+import org.lwjgl.vulkan.*;
+
+import java.util.List;
+import java.util.Map;
+
+public interface DeviceBuildInformation {
+
+    boolean isApplicationFeatureSupported(String name);
+
+    ApplicationFeature.Instance getApplicationFeature(String name);
+
+    VulkanInstance getInstance();
+
+    VkPhysicalDevice getPhysicalDevice();
+
+    VkPhysicalDeviceProperties getPhysicalDeviceProperties();
+
+    VkPhysicalDeviceFeatures getPhysicalDeviceFeatures();
+
+    /**
+     * Checks if a device extension is supported
+     *
+     * @param extension The name of the extension.
+     * @return True if the extension is supported, false otherwise.
+     */
+    boolean isExtensionAvailable(String extension);
+
+    /**
+     * Retrieves all supported extensions.
+     *
+     * @return A map of all supported extensions
+     */
+    Map<String, VkExtensionProperties> getAllExtensionProperties();
+
+    /**
+     * Returns the properties of a device extension or null if the extension is not supported.
+     *
+     * @param extension The name of the extension
+     * @return The properties of the extension or null if it is not supported
+     */
+    VkExtensionProperties getExtensionProperties(String extension);
+
+    /**
+     * Lists all queue families.
+     *
+     * @return A list of all available queue families.
+     */
+    List<VkQueueFamilyProperties> getQueueFamilyProperties();
+
+    /**
+     * Finds all queue families that satisfy the specified criteria.
+     *
+     * @param flags The flags that the queue must support
+     * @param noTransferLimit If false only queues that have a min transfer granularity of 1 will be returned
+     * @return A list of queue family indices that satisfy the requirements
+     */
+    List<Integer> findQueueFamilies(int flags, boolean noTransferLimit);
+}

--- a/src/main/java/me/hydos/rosella/init/DeviceBuildInformation.java
+++ b/src/main/java/me/hydos/rosella/init/DeviceBuildInformation.java
@@ -1,6 +1,7 @@
 package me.hydos.rosella.init;
 
 import me.hydos.rosella.init.features.ApplicationFeature;
+import me.hydos.rosella.util.NamedID;
 import org.lwjgl.vulkan.*;
 
 import java.util.List;
@@ -8,9 +9,9 @@ import java.util.Map;
 
 public interface DeviceBuildInformation {
 
-    boolean isApplicationFeatureSupported(String name);
+    boolean isApplicationFeatureSupported(NamedID name);
 
-    ApplicationFeature.Instance getApplicationFeature(String name);
+    ApplicationFeature.Instance getApplicationFeature(NamedID name);
 
     VulkanInstance getInstance();
 

--- a/src/main/java/me/hydos/rosella/init/DeviceBuilder.java
+++ b/src/main/java/me/hydos/rosella/init/DeviceBuilder.java
@@ -23,9 +23,9 @@ public class DeviceBuilder {
 
     private final List<ApplicationFeature> applicationFeatures;
     private final Set<String> requiredFeatures;
-    private final LegacyVulkanInstance instance;
+    private final VulkanInstance instance;
 
-    public DeviceBuilder(@NotNull LegacyVulkanInstance instance, @NotNull InitializationRegistry registry) {
+    public DeviceBuilder(@NotNull VulkanInstance instance, @NotNull InitializationRegistry registry) {
         this.instance = instance;
         this.applicationFeatures = registry.getOrderedFeatures();
         this.requiredFeatures = registry.getRequiredApplicationFeatures();
@@ -42,13 +42,13 @@ public class DeviceBuilder {
         List<DeviceMeta> devices = new ArrayList<>();
         try (MemoryStack stack = MemoryStack.stackPush()) {
             IntBuffer deviceCount = stack.mallocInt(1);
-            VkUtils.ok(VK10.vkEnumeratePhysicalDevices(this.instance.rawInstance, deviceCount, null));
+            VkUtils.ok(VK10.vkEnumeratePhysicalDevices(this.instance.getInstance(), deviceCount, null));
 
             PointerBuffer pPhysicalDevices = stack.mallocPointer(deviceCount.get(0));
-            VkUtils.ok(VK10.vkEnumeratePhysicalDevices(this.instance.rawInstance, deviceCount, pPhysicalDevices));
+            VkUtils.ok(VK10.vkEnumeratePhysicalDevices(this.instance.getInstance(), deviceCount, pPhysicalDevices));
 
             for(int i = 0; i < deviceCount.get(0); i++) {
-                devices.add(new DeviceMeta(new VkPhysicalDevice(pPhysicalDevices.get(i), this.instance.rawInstance), stack));
+                devices.add(new DeviceMeta(new VkPhysicalDevice(pPhysicalDevices.get(i), this.instance.getInstance()), stack));
             }
 
             devices.forEach(DeviceMeta::processSupport);

--- a/src/main/java/me/hydos/rosella/init/DeviceBuilder.java
+++ b/src/main/java/me/hydos/rosella/init/DeviceBuilder.java
@@ -1,0 +1,355 @@
+package me.hydos.rosella.init;
+
+import me.hydos.rosella.Rosella;
+import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.VulkanQueue;
+import me.hydos.rosella.util.VkUtils;
+import me.hydos.rosella.vkobjects.VulkanInstance;
+import org.jetbrains.annotations.NotNull;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.*;
+
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.util.*;
+
+/**
+ * Used to build devices.
+ *
+ * This class will select and create the best device based on the criteria specified by the provided InitializationRegistry.
+ */
+public class DeviceBuilder {
+
+    private final List<ApplicationFeature> applicationFeatures;
+    private final Set<String> requiredFeatures;
+    private final VulkanInstance instance;
+
+    public DeviceBuilder(@NotNull VulkanInstance instance, @NotNull InitializationRegistry registry) {
+        this.instance = instance;
+        this.applicationFeatures = registry.getOrderedFeatures();
+        this.requiredFeatures = registry.getRequiredApplicationFeatures();
+    }
+
+    /**
+     * Enumerates all available devices and selects the best. If no compatible device can be found throws a
+     * runtime error.
+     *
+     * @return The initialized vulkan device
+     * @throws RuntimeException if no compatible device can be found or an error occurs
+     */
+    public VulkanDevice build() throws RuntimeException {
+        List<DeviceMeta> devices = new ArrayList<>();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer deviceCount = stack.mallocInt(1);
+            VkUtils.ok(VK10.vkEnumeratePhysicalDevices(this.instance.rawInstance, deviceCount, null));
+
+            PointerBuffer pPhysicalDevices = stack.mallocPointer(deviceCount.get(0));
+            VkUtils.ok(VK10.vkEnumeratePhysicalDevices(this.instance.rawInstance, deviceCount, pPhysicalDevices));
+
+            for(int i = 0; i < deviceCount.get(0); i++) {
+                devices.add(new DeviceMeta(new VkPhysicalDevice(pPhysicalDevices.get(i), this.instance.rawInstance), stack));
+            }
+
+            devices.forEach(DeviceMeta::processSupport);
+            devices.sort((a, b) -> { // This is sorting in descending order so that we can use the first device
+                if(!a.isValid() || !b.isValid()) {
+                    if(a.isValid()) {
+                        return -1;
+                    }
+                    if(b.isValid()) {
+                        return 1;
+                    }
+                    return 0;
+                }
+                if(a.getFeatureRanking() != b.getFeatureRanking()) {
+                    return (int) (b.getFeatureRanking() - a.getFeatureRanking());
+                }
+                if(a.getPerformanceRanking() != b.getPerformanceRanking()) {
+                    return b.getPerformanceRanking() - a.getPerformanceRanking();
+                }
+                return 0;
+            });
+
+            DeviceMeta selectedDevice = devices.get(0);
+            if(!selectedDevice.isValid()) {
+                throw new RuntimeException("Failed to find suitable device");
+            }
+
+            return selectedDevice.createDevice();
+        }
+    }
+
+    public class DeviceMeta {
+        private final MemoryStack stack;
+
+        private final Set<String> unsatisfiedRequirements = new HashSet<>();
+        private final Map<String, ApplicationFeature.Instance> features = new HashMap<>();
+        private final ArrayList<ApplicationFeature.Instance> sortedFeatures = new ArrayList<>();
+
+        public final VkPhysicalDevice physicalDevice;
+        public final VkPhysicalDeviceProperties properties;
+        public final VkPhysicalDeviceMemoryProperties memoryProperties;
+        public final Map<String, VkExtensionProperties> extensionProperties;
+        public final List<VkQueueFamilyProperties> queueFamilyProperties;
+
+        private boolean isBuilding = false;
+        private final List<QueueRequest> queueRequests = new ArrayList<>();
+        private final Set<String> enabledExtensions = new HashSet<>();
+        private final VkPhysicalDeviceFeatures enabledFeatures;
+
+        private DeviceMeta(VkPhysicalDevice physicalDevice, MemoryStack stack) {
+            this.stack = stack;
+            this.physicalDevice = physicalDevice;
+            this.unsatisfiedRequirements.addAll(requiredFeatures);
+            applicationFeatures.forEach(feature -> sortedFeatures.add(feature.createInstance()));
+            this.sortedFeatures.forEach(feature -> features.put(feature.getFeatureName(), feature));
+
+            IntBuffer count = stack.mallocInt(1);
+
+            this.properties = VkPhysicalDeviceProperties.mallocStack(stack);
+            VK10.vkGetPhysicalDeviceProperties(physicalDevice, this.properties);
+
+            this.memoryProperties = VkPhysicalDeviceMemoryProperties.mallocStack(stack);
+            VK10.vkGetPhysicalDeviceMemoryProperties(physicalDevice, memoryProperties);
+
+            VK10.vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, count, null);
+            VkQueueFamilyProperties.Buffer queueFamilyPropertiesBuffer = VkQueueFamilyProperties.mallocStack(count.get(0), stack);
+            VK10.vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, count, queueFamilyPropertiesBuffer);
+            ArrayList<VkQueueFamilyProperties> queueFamilyPropertiesList = new ArrayList<>();
+            for(int i = 0; i < count.get(0); i++) {
+                queueFamilyPropertiesList.add(queueFamilyPropertiesBuffer.get(i));
+            }
+            this.queueFamilyProperties = Collections.unmodifiableList(queueFamilyPropertiesList);
+
+            VkUtils.ok(VK10.vkEnumerateDeviceExtensionProperties(this.physicalDevice, (CharSequence) null, count, null));
+            VkExtensionProperties.Buffer extensionPropertiesBuffer = VkExtensionProperties.mallocStack(count.get(0), stack);
+            VkUtils.ok(VK10.vkEnumerateDeviceExtensionProperties(this.physicalDevice, (CharSequence) null, count, extensionPropertiesBuffer));
+            Map<String, VkExtensionProperties> extensionPropertiesMap = new HashMap<>();
+            for(int i = 0; i < count.get(0); i++) {
+                VkExtensionProperties properties = extensionPropertiesBuffer.get(i);
+                extensionPropertiesMap.put(properties.extensionNameString(), properties);
+            }
+            this.extensionProperties = Collections.unmodifiableMap(extensionPropertiesMap);
+
+            this.enabledFeatures = VkPhysicalDeviceFeatures.callocStack(stack);
+        }
+
+        private void processSupport() {
+            for(ApplicationFeature.Instance feature : this.sortedFeatures) {
+                try {
+                    feature.testFeatureSupport(this);
+                    if(feature.isSupported()) {
+                        this.unsatisfiedRequirements.remove(feature.getFeatureName());
+                    }
+                } catch (Exception ex) {
+                    Rosella.LOGGER.warn("Exception during support test for feature \"" + feature.getFeatureName() + "\"", ex);
+                }
+            }
+        }
+
+        /**
+         * @return true if all required features are met by this device.
+         */
+        private boolean isValid() {
+            return unsatisfiedRequirements.isEmpty();
+        }
+
+        /**
+         * @return A ranking based on what features are supported. The greater the better.
+         */
+        private long getFeatureRanking() {
+            return this.sortedFeatures.stream().filter(ApplicationFeature.Instance::isSupported).count();
+        }
+
+        /**
+         * @return A ranking based on what the expected performance of the device is. The greater the better.
+         */
+        private int getPerformanceRanking() {
+            return switch (properties.deviceType()) {
+                case VK10.VK_PHYSICAL_DEVICE_TYPE_CPU, VK10.VK_PHYSICAL_DEVICE_TYPE_OTHER -> 0;
+                case VK10.VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU -> 1;
+                case VK10.VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU -> 2;
+                case VK10.VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU -> 3;
+                default -> throw new RuntimeException("Device type was not recognized!");
+            };
+        }
+
+        private VulkanDevice createDevice() {
+            assert(!this.isBuilding);
+            this.isBuilding = true;
+
+            Map<String, Object> enabledFeatures = new HashMap<>();
+
+            for(ApplicationFeature.Instance feature : this.sortedFeatures) {
+                try {
+                    if(feature.isSupported()) {
+                        Object metadata = feature.enableFeature(this);
+                        enabledFeatures.put(feature.getFeatureName(), metadata);
+                    }
+                } catch (Exception ex) {
+                    Rosella.LOGGER.warn("Exception while enabling feature \"" + feature.getFeatureName() + "\"", ex);
+                }
+            }
+
+            VkDeviceCreateInfo deviceInfo = VkDeviceCreateInfo.callocStack(this.stack);
+            deviceInfo.sType(VK10.VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO);
+            deviceInfo.pQueueCreateInfos(this.generateQueueMappings());
+            deviceInfo.ppEnabledExtensionNames(this.generateEnabledExtensionNames());
+            deviceInfo.pEnabledFeatures(this.enabledFeatures);
+
+            PointerBuffer pDevice = this.stack.mallocPointer(1);
+            VkUtils.ok(VK10.vkCreateDevice(this.physicalDevice, deviceInfo, null, pDevice));
+
+            VkDevice device = new VkDevice(pDevice.get(0), this.physicalDevice, deviceInfo);
+
+            this.fulfillQueueRequests(device);
+
+            return new VulkanDevice(device, enabledFeatures);
+        }
+
+        private VkDeviceQueueCreateInfo.Buffer generateQueueMappings() {
+            int[] nextQueueIndices = new int[this.queueFamilyProperties.size()];
+
+            for(QueueRequest request : this.queueRequests) {
+                int index = nextQueueIndices[request.family]++;
+                request.index = index % this.queueFamilyProperties.get(request.family).queueCount();
+            }
+
+            int familyCount = 0;
+            for(int i : nextQueueIndices) {
+                if(i != 0) {
+                    familyCount++;
+                }
+            }
+
+            VkDeviceQueueCreateInfo.Buffer queueCreateInfos = VkDeviceQueueCreateInfo.callocStack(familyCount, this.stack);
+
+            for(int family = 0; family < nextQueueIndices.length; family++) {
+                if(nextQueueIndices[family] == 0) {
+                    continue;
+                }
+
+
+                FloatBuffer priorities = this.stack.mallocFloat(Math.min(nextQueueIndices[family], this.queueFamilyProperties.get(family).queueCount()));
+                while(priorities.hasRemaining()) {
+                    priorities.put(1.0f);
+                }
+                priorities.rewind();
+
+                VkDeviceQueueCreateInfo info = queueCreateInfos.get();
+                info.sType(VK10.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO);
+                info.queueFamilyIndex(family);
+                info.pQueuePriorities(priorities);
+            }
+
+            return queueCreateInfos;
+        }
+
+        private void fulfillQueueRequests(VkDevice device) {
+            int queueFamilyCount = this.queueFamilyProperties.size();
+            int maxQueueCount = this.queueFamilyProperties.stream().map(VkQueueFamilyProperties::queueCount).max(Comparator.comparingInt(a -> a)).orElse(0);
+
+            VulkanQueue[][] requests = new VulkanQueue[queueFamilyCount][maxQueueCount];
+
+            PointerBuffer pQueue = this.stack.mallocPointer(1);
+
+            for(QueueRequest request : this.queueRequests) {
+                int f = request.family, i = request.index;
+                if(requests[f][i] == null) {
+                    VK10.vkGetDeviceQueue(device, f, i, pQueue);
+                    requests[f][i] = new VulkanQueue(new VkQueue(pQueue.get(0), device), f);
+                }
+
+                request.queue = requests[f][i];
+            }
+        }
+
+        private PointerBuffer generateEnabledExtensionNames() {
+            if(this.enabledExtensions.isEmpty()) {
+                return null;
+            }
+
+            PointerBuffer names = this.stack.mallocPointer(this.enabledExtensions.size());
+            for(String extension : this.enabledExtensions) {
+                names.put(this.stack.UTF8(extension));
+            }
+
+            return names.rewind();
+        }
+
+        public boolean isApplicationFeatureSupported(String name) {
+            ApplicationFeature.Instance feature = this.features.getOrDefault(name, null);
+            if(feature == null) {
+                return false;
+            }
+
+            return feature.isSupported();
+        }
+
+        public ApplicationFeature.Instance getApplicationFeature(String name) {
+            return this.features.getOrDefault(name, null);
+        }
+
+        /**
+         * Checks if there exists a queue family that supports all specified flags.
+         *
+         * @param flags The flags the queue must support
+         * @return true if a queue family exists supporting all specified flags
+         */
+        public boolean hasQueueWithFlags(int flags) {
+            return this.queueFamilyProperties.stream().anyMatch(props -> (props.queueFlags() & flags) == flags);
+        }
+
+        /**
+         * Checks if this device supports a extension.
+         *
+         * @param name The name of the extension.
+         * @return True if the extension is supported, false otherwise.
+         */
+        public boolean isExtensionSupported(String name) {
+            return this.extensionProperties.containsKey(name);
+        }
+
+        /**
+         * Adds a new queue request. Must only be called during the device configuration process.
+         *
+         * @param family The family that is requested.
+         * @return A QueueRequest instance that can be used to later retrieve the requested queue.
+         */
+        public QueueRequest addQueueRequest(int family) {
+            assert(this.isBuilding);
+
+            QueueRequest request = new QueueRequest(family);
+            this.queueRequests.add(request);
+            return request;
+        }
+
+        /**
+         * Adds a extension to the set of enabled extensions. This function does not validate if the extension
+         * is actually supported.
+         * Must only be called during the device configuration process.
+         *
+         * @param extension The name of the extension.
+         */
+        public void enableExtension(String extension) {
+            assert(this.isBuilding);
+
+            this.enabledExtensions.add(extension);
+        }
+
+        public static class QueueRequest {
+            private final int family;
+            private int index;
+            private VulkanQueue queue = null;
+
+            private QueueRequest(int family) {
+                this.family = family;
+            }
+
+            public VulkanQueue resolve() {
+                return this.queue;
+            }
+        }
+    }
+}

--- a/src/main/java/me/hydos/rosella/init/DeviceBuilder.java
+++ b/src/main/java/me/hydos/rosella/init/DeviceBuilder.java
@@ -4,7 +4,7 @@ import me.hydos.rosella.Rosella;
 import me.hydos.rosella.device.VulkanDevice;
 import me.hydos.rosella.device.VulkanQueue;
 import me.hydos.rosella.util.VkUtils;
-import me.hydos.rosella.vkobjects.VulkanInstance;
+import me.hydos.rosella.vkobjects.LegacyVulkanInstance;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
@@ -23,9 +23,9 @@ public class DeviceBuilder {
 
     private final List<ApplicationFeature> applicationFeatures;
     private final Set<String> requiredFeatures;
-    private final VulkanInstance instance;
+    private final LegacyVulkanInstance instance;
 
-    public DeviceBuilder(@NotNull VulkanInstance instance, @NotNull InitializationRegistry registry) {
+    public DeviceBuilder(@NotNull LegacyVulkanInstance instance, @NotNull InitializationRegistry registry) {
         this.instance = instance;
         this.applicationFeatures = registry.getOrderedFeatures();
         this.requiredFeatures = registry.getRequiredApplicationFeatures();

--- a/src/main/java/me/hydos/rosella/init/DeviceBuilder.java
+++ b/src/main/java/me/hydos/rosella/init/DeviceBuilder.java
@@ -249,7 +249,7 @@ public class DeviceBuilder {
                 info.pQueuePriorities(priorities);
             }
 
-            return queueCreateInfos;
+            return queueCreateInfos.rewind();
         }
 
         private void fulfillQueueRequests(VkDevice device) {

--- a/src/main/java/me/hydos/rosella/init/DeviceBuilder.java
+++ b/src/main/java/me/hydos/rosella/init/DeviceBuilder.java
@@ -4,6 +4,7 @@ import me.hydos.rosella.Rosella;
 import me.hydos.rosella.device.VulkanDevice;
 import me.hydos.rosella.device.VulkanQueue;
 import me.hydos.rosella.init.features.ApplicationFeature;
+import me.hydos.rosella.util.NamedID;
 import me.hydos.rosella.util.VkUtils;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.PointerBuffer;
@@ -24,7 +25,7 @@ import java.util.concurrent.Future;
 public class DeviceBuilder {
 
     private final List<ApplicationFeature> applicationFeatures;
-    private final Set<String> requiredFeatures;
+    private final Set<NamedID> requiredFeatures;
     private final VulkanInstance instance;
 
     public DeviceBuilder(@NotNull VulkanInstance instance, @NotNull InitializationRegistry registry) {
@@ -85,8 +86,8 @@ public class DeviceBuilder {
     public class DeviceMeta implements DeviceBuildInformation, DeviceBuildConfigurator {
         private final MemoryStack stack;
 
-        private final Set<String> unsatisfiedRequirements = new HashSet<>();
-        private final Map<String, ApplicationFeature.Instance> features = new HashMap<>();
+        private final Set<NamedID> unsatisfiedRequirements = new HashSet<>();
+        private final Map<NamedID, ApplicationFeature.Instance> features = new HashMap<>();
         private final ArrayList<ApplicationFeature.Instance> sortedFeatures = new ArrayList<>();
 
         private final VkPhysicalDevice physicalDevice;
@@ -181,7 +182,7 @@ public class DeviceBuilder {
             assert(!this.isBuilding);
             this.isBuilding = true;
 
-            Map<String, Object> enabledFeatures = new HashMap<>();
+            Map<NamedID, Object> enabledFeatures = new HashMap<>();
 
             for(ApplicationFeature.Instance feature : this.sortedFeatures) {
                 try {
@@ -281,7 +282,7 @@ public class DeviceBuilder {
         }
 
         @Override
-        public boolean isApplicationFeatureSupported(String name) {
+        public boolean isApplicationFeatureSupported(NamedID name) {
             ApplicationFeature.Instance feature = this.features.getOrDefault(name, null);
             if(feature == null) {
                 return false;
@@ -291,7 +292,7 @@ public class DeviceBuilder {
         }
 
         @Override
-        public ApplicationFeature.Instance getApplicationFeature(String name) {
+        public ApplicationFeature.Instance getApplicationFeature(NamedID name) {
             return this.features.getOrDefault(name, null);
         }
 

--- a/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
+++ b/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
@@ -1,5 +1,7 @@
 package me.hydos.rosella.init;
 
+import me.hydos.rosella.logging.DebugLogger;
+
 import java.util.*;
 
 /**
@@ -8,6 +10,7 @@ import java.util.*;
 public class InitializationRegistry {
 
     private boolean enableValidation = false;
+    private DebugLogger validationDebugLogger = null;
     private VulkanVersion minRequiredVersion = VulkanVersion.VULKAN_1_0;
     private VulkanVersion maxSupportedVersion = VulkanVersion.VULKAN_1_2;
 
@@ -19,12 +22,17 @@ public class InitializationRegistry {
     private final Map<String, MarkedFeature> features = new HashMap<>();
     private final Set<String> requiredFeatures = new HashSet<>();
 
-    public void setEnableValidation(boolean enable) {
-        this.enableValidation = enable;
+    public void enableValidation(DebugLogger logger) {
+        this.enableValidation = true;
+        this.validationDebugLogger = logger;
     }
 
     public boolean getEnableValidation() {
         return this.enableValidation;
+    }
+
+    public DebugLogger getValidationDebugLogger() {
+        return this.validationDebugLogger;
     }
 
     public void addRequiredInstanceLayer(String layer) {

--- a/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
+++ b/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
@@ -1,7 +1,7 @@
 package me.hydos.rosella.init;
 
 import me.hydos.rosella.debug.VulkanDebugCallback;
-import me.hydos.rosella.logging.DebugLogger;
+import me.hydos.rosella.init.features.ApplicationFeature;
 
 import java.util.*;
 

--- a/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
+++ b/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
@@ -3,11 +3,13 @@ package me.hydos.rosella.init;
 import java.util.*;
 
 /**
- * A class used to collect any callbacks that are used for device and instance initialization.
+ * A class used to collect any callbacks and settings that are used for device and instance initialization.
  */
 public class InitializationRegistry {
 
     private boolean enableValidation = false;
+    private VulkanVersion minRequiredVersion = VulkanVersion.VULKAN_1_0;
+    private VulkanVersion maxSupportedVersion = VulkanVersion.VULKAN_1_2;
 
     private final Set<String> requiredInstanceExtensions = new HashSet<>();
     private final Set<String> optionalInstanceExtensions = new HashSet<>();
@@ -39,6 +41,42 @@ public class InitializationRegistry {
 
     public void addOptionalInstanceExtension(String extension) {
         this.optionalInstanceExtensions.add(extension);
+    }
+
+    public Set<String> getRequiredInstanceLayers() {
+        return Collections.unmodifiableSet(this.requiredInstanceLayers);
+    }
+
+    public Set<String> getOptionalInstanceLayers() {
+        return Collections.unmodifiableSet(this.optionalInstanceLayers);
+    }
+
+    public Set<String> getRequiredInstanceExtensions() {
+        return Collections.unmodifiableSet(this.requiredInstanceExtensions);
+    }
+
+    public Set<String> getOptionalInstanceExtensions() {
+        return Collections.unmodifiableSet(this.optionalInstanceExtensions);
+    }
+
+    public void setMinimumVulkanVersion(VulkanVersion version) {
+        if(version.getVersionNumber() > this.minRequiredVersion.getVersionNumber()) {
+            this.minRequiredVersion = version;
+        }
+    }
+
+    public void setMaximumVulkanVersion(VulkanVersion version) {
+        if(version.getVersionNumber() < this.maxSupportedVersion.getVersionNumber()) {
+            this.maxSupportedVersion = version;
+        }
+    }
+
+    public VulkanVersion getMinimumVulkanVersion() {
+        return this.minRequiredVersion;
+    }
+
+    public VulkanVersion getMaxSupportedVersion() {
+        return this.maxSupportedVersion;
     }
 
     /**

--- a/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
+++ b/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
@@ -2,6 +2,7 @@ package me.hydos.rosella.init;
 
 import me.hydos.rosella.debug.VulkanDebugCallback;
 import me.hydos.rosella.init.features.ApplicationFeature;
+import me.hydos.rosella.util.NamedID;
 
 import java.util.*;
 
@@ -21,8 +22,8 @@ public class InitializationRegistry {
     private final Set<String> requiredInstanceLayers = new HashSet<>();
     private final Set<String> optionalInstanceLayers = new HashSet<>();
 
-    private final Map<String, MarkedFeature> features = new HashMap<>();
-    private final Set<String> requiredFeatures = new HashSet<>();
+    private final Map<NamedID, MarkedFeature> features = new HashMap<>();
+    private final Set<NamedID> requiredFeatures = new HashSet<>();
 
     public void enableValidation(boolean enable) {
         this.validationEnabled = enable;
@@ -98,7 +99,7 @@ public class InitializationRegistry {
      *
      * @param name The name of the feature that is required. The feature does not have to be registered yet.
      */
-    public void addRequiredApplicationFeature(String name) {
+    public void addRequiredApplicationFeature(NamedID name) {
         this.requiredFeatures.add(name);
     }
 
@@ -107,7 +108,7 @@ public class InitializationRegistry {
      *
      * @return A unmodifiable set of all required features.
      */
-    public Set<String> getRequiredApplicationFeatures() {
+    public Set<NamedID> getRequiredApplicationFeatures() {
         return Collections.unmodifiableSet(this.requiredFeatures);
     }
 
@@ -155,7 +156,7 @@ public class InitializationRegistry {
 
         feature.mark = MarkedFeature.Mark.PROCESSING;
 
-        for(String dependency : feature.feature.dependencies) {
+        for(NamedID dependency : feature.feature.dependencies) {
             MarkedFeature next = this.features.get(dependency);
             if(next != null) {
                 sortVisit(next, sorted);

--- a/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
+++ b/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
@@ -1,5 +1,6 @@
 package me.hydos.rosella.init;
 
+import me.hydos.rosella.debug.VulkanDebugCallback;
 import me.hydos.rosella.logging.DebugLogger;
 
 import java.util.*;
@@ -9,10 +10,11 @@ import java.util.*;
  */
 public class InitializationRegistry {
 
-    private boolean enableValidation = false;
-    private DebugLogger validationDebugLogger = null;
+    private boolean validationEnabled = false;
     private VulkanVersion minRequiredVersion = VulkanVersion.VULKAN_1_0;
     private VulkanVersion maxSupportedVersion = VulkanVersion.VULKAN_1_2;
+
+    private final Set<VulkanDebugCallback.Callback> debugCallbacks = new HashSet<>();
 
     private final Set<String> requiredInstanceExtensions = new HashSet<>();
     private final Set<String> optionalInstanceExtensions = new HashSet<>();
@@ -22,17 +24,20 @@ public class InitializationRegistry {
     private final Map<String, MarkedFeature> features = new HashMap<>();
     private final Set<String> requiredFeatures = new HashSet<>();
 
-    public void enableValidation(DebugLogger logger) {
-        this.enableValidation = true;
-        this.validationDebugLogger = logger;
+    public void enableValidation(boolean enable) {
+        this.validationEnabled = enable;
     }
 
     public boolean getEnableValidation() {
-        return this.enableValidation;
+        return this.validationEnabled;
     }
 
-    public DebugLogger getValidationDebugLogger() {
-        return this.validationDebugLogger;
+    public void addDebugCallback(VulkanDebugCallback.Callback callback) {
+        this.debugCallbacks.add(callback);
+    }
+
+    public Set<VulkanDebugCallback.Callback> getDebugCallbacks() {
+        return Collections.unmodifiableSet(debugCallbacks);
     }
 
     public void addRequiredInstanceLayer(String layer) {

--- a/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
+++ b/src/main/java/me/hydos/rosella/init/InitializationRegistry.java
@@ -1,0 +1,132 @@
+package me.hydos.rosella.init;
+
+import java.util.*;
+
+/**
+ * A class used to collect any callbacks that are used for device and instance initialization.
+ */
+public class InitializationRegistry {
+
+    private boolean enableValidation = false;
+
+    private final Set<String> requiredInstanceExtensions = new HashSet<>();
+    private final Set<String> optionalInstanceExtensions = new HashSet<>();
+    private final Set<String> requiredInstanceLayers = new HashSet<>();
+    private final Set<String> optionalInstanceLayers = new HashSet<>();
+
+    private final Map<String, MarkedFeature> features = new HashMap<>();
+    private final Set<String> requiredFeatures = new HashSet<>();
+
+    public void setEnableValidation(boolean enable) {
+        this.enableValidation = enable;
+    }
+
+    public boolean getEnableValidation() {
+        return this.enableValidation;
+    }
+
+    public void addRequiredInstanceLayer(String layer) {
+        this.requiredInstanceLayers.add(layer);
+    }
+
+    public void addOptionalInstanceLayer(String layer) {
+        this.optionalInstanceLayers.add(layer);
+    }
+
+    public void addRequiredInstanceExtensions(String extension) {
+        this.requiredInstanceExtensions.add(extension);
+    }
+
+    public void addOptionalInstanceExtension(String extension) {
+        this.optionalInstanceExtensions.add(extension);
+    }
+
+    /**
+     * Marks a feature as required. This means that during device selection no device will be used
+     * that does not support all required features.
+     *
+     * @param name The name of the feature that is required. The feature does not have to be registered yet.
+     */
+    public void addRequiredApplicationFeature(String name) {
+        this.requiredFeatures.add(name);
+    }
+
+    /**
+     * Returns an unmodifiable set of all required features.
+     *
+     * @return A unmodifiable set of all required features.
+     */
+    public Set<String> getRequiredApplicationFeatures() {
+        return Collections.unmodifiableSet(this.requiredFeatures);
+    }
+
+    /**
+     * Registers a application feature into this registry.
+     *
+     * @param feature The feature to register
+     */
+    public void registerApplicationFeature(ApplicationFeature feature) {
+        if(this.features.containsKey(feature.name)) {
+            throw new RuntimeException("Feature " + feature.name + " is already registered");
+        }
+
+        features.put(feature.name, new MarkedFeature(feature));
+    }
+
+    /**
+     * Topologically sorts all features and returns them as a list.
+     * The list can be iterated from beginning to end to ensure all dependencies are always met.
+     *
+     * @return A topologically sorted list of all registered ApplicationFeatures.
+     */
+    public List<ApplicationFeature> getOrderedFeatures() {
+        ArrayList<ApplicationFeature> sortedFeatures = new ArrayList<>();
+        sortedFeatures.ensureCapacity(this.features.size());
+
+        this.features.values().forEach(feature -> feature.mark = MarkedFeature.Mark.UNMARKED);
+
+        for(MarkedFeature feature : features.values()) {
+            if(feature.mark == MarkedFeature.Mark.UNMARKED) {
+                sortVisit(feature, sortedFeatures);
+            }
+        }
+
+        return sortedFeatures;
+    }
+
+    private void sortVisit(MarkedFeature feature, ArrayList<ApplicationFeature> sorted) {
+        if(feature.mark == MarkedFeature.Mark.PROCESSED) {
+            return;
+        }
+        if(feature.mark == MarkedFeature.Mark.PROCESSING) {
+            throw new RuntimeException("Dependency graph of application features is not acyclic!");
+        }
+
+        feature.mark = MarkedFeature.Mark.PROCESSING;
+
+        for(String dependency : feature.feature.dependencies) {
+            MarkedFeature next = this.features.get(dependency);
+            if(next != null) {
+                sortVisit(next, sorted);
+            }
+        }
+
+        feature.mark = MarkedFeature.Mark.PROCESSED;
+        sorted.add(feature.feature);
+    }
+
+    private static class MarkedFeature {
+        public final ApplicationFeature feature;
+        public Mark mark = Mark.UNMARKED;
+
+        public MarkedFeature(ApplicationFeature feature) {
+            this.feature = feature;
+        }
+
+        public enum Mark {
+            UNMARKED,
+            PROCESSING,
+            PROCESSED,
+        }
+    }
+}

--- a/src/main/java/me/hydos/rosella/init/InstanceBuilder.java
+++ b/src/main/java/me/hydos/rosella/init/InstanceBuilder.java
@@ -31,6 +31,9 @@ public class InstanceBuilder {
         if(!registry.getDebugCallbacks().isEmpty() || registry.getEnableValidation()) {
             this.enableDebugUtils = true;
             this.debugUtilsCallback = new VulkanDebugCallback();
+
+            registry.getDebugCallbacks().forEach(this.debugUtilsCallback::registerCallback);
+
         } else {
             this.enableDebugUtils = false;
             this.debugUtilsCallback = null;

--- a/src/main/java/me/hydos/rosella/init/InstanceBuilder.java
+++ b/src/main/java/me/hydos/rosella/init/InstanceBuilder.java
@@ -1,7 +1,114 @@
 package me.hydos.rosella.init;
 
+import me.hydos.rosella.util.VkUtils;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.*;
+
+import java.nio.IntBuffer;
+import java.util.HashSet;
+import java.util.Set;
+
 public class InstanceBuilder {
 
+    private final InitializationRegistry registry;
+
     public InstanceBuilder(InitializationRegistry registry) {
+        this.registry = registry;
+    }
+
+    public VulkanInstance build(String applicationName, int applicationVersion) {
+        try(MemoryStack stack = MemoryStack.stackPush()) {
+            int supportedVersionNumber = getSupportedVersion(stack);
+            if(supportedVersionNumber < this.registry.getMinimumVulkanVersion().getVersionNumber()) {
+                throw new RuntimeException("Minimum vulkan version " + this.registry.getMinimumVulkanVersion().toString() + " is not supported!");
+            }
+
+            VkApplicationInfo appInfo = VkApplicationInfo.callocStack(stack);
+            appInfo.sType(VK10.VK_STRUCTURE_TYPE_APPLICATION_INFO);
+            appInfo.pApplicationName(stack.UTF8(applicationName));
+            appInfo.applicationVersion(applicationVersion);
+            appInfo.pEngineName(stack.UTF8("Rosella"));
+            appInfo.engineVersion(VK10.VK_MAKE_VERSION(0, 1, 0)); // TODO
+            appInfo.apiVersion(this.registry.getMaxSupportedVersion().getVersionNumber());
+
+            VkInstanceCreateInfo createInfo = VkInstanceCreateInfo.callocStack(stack);
+            createInfo.sType(VK10.VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO);
+            createInfo.pApplicationInfo(appInfo);
+            createInfo.ppEnabledLayerNames(getLayerBuffer(stack));
+            createInfo.ppEnabledExtensionNames(getExtensionBuffer(stack));
+
+            PointerBuffer pInstance = stack.mallocPointer(1);
+            VkUtils.ok(VK10.vkCreateInstance(createInfo, null, pInstance));
+
+            VkInstance instance = new VkInstance(pInstance.get(0), createInfo);
+            return new VulkanInstance(instance);
+        }
+    }
+
+    private int getSupportedVersion(MemoryStack stack) {
+        IntBuffer versionBuffer = stack.mallocInt(1);
+
+        try { // Yes this is ugly but i have no better plan to validate that the function actually exists
+            VK11.vkEnumerateInstanceVersion(versionBuffer);
+        } catch (NullPointerException ex) {
+            return VulkanVersion.VULKAN_1_0.getVersionNumber();
+        }
+
+        return versionBuffer.get(0);
+    }
+
+    private PointerBuffer getLayerBuffer(MemoryStack stack) {
+        IntBuffer count = stack.mallocInt(1);
+        VkUtils.ok(VK10.vkEnumerateInstanceLayerProperties(count, null));
+        VkLayerProperties.Buffer propertiesBuffer = VkLayerProperties.mallocStack(count.get(0), stack);
+        VkUtils.ok(VK10.vkEnumerateInstanceLayerProperties(count, propertiesBuffer));
+
+        Set<String> supportedLayers = new HashSet<>();
+        for(int i = 0; i < count.get(0); i++) {
+            supportedLayers.add(propertiesBuffer.get(i).layerNameString());
+        }
+
+        if(!supportedLayers.containsAll(this.registry.getRequiredInstanceLayers())) {
+            throw new RuntimeException("Required instance layers not found");
+        }
+
+        Set<String> enabledLayers = new HashSet<>();
+        enabledLayers.addAll(this.registry.getRequiredInstanceLayers());
+        enabledLayers.addAll(this.registry.getOptionalInstanceLayers().stream().filter(supportedLayers::contains).toList());
+
+        PointerBuffer layerNames = stack.mallocPointer(enabledLayers.size());
+        for(String layer : enabledLayers) {
+            layerNames.put(stack.UTF8(layer));
+        }
+
+        return layerNames.rewind();
+    }
+
+    private PointerBuffer getExtensionBuffer(MemoryStack stack) {
+        IntBuffer count = stack.mallocInt(1);
+        VkUtils.ok(VK10.vkEnumerateInstanceExtensionProperties((CharSequence) null, count, null));
+        VkExtensionProperties.Buffer propertiesBuffer = VkExtensionProperties.mallocStack(count.get(0), stack);
+        VkUtils.ok(VK10.vkEnumerateInstanceExtensionProperties((CharSequence) null, count, propertiesBuffer));
+
+        Set<String> supportedExtensions = new HashSet<>();
+        for(int i = 0; i < count.get(0); i++) {
+            supportedExtensions.add(propertiesBuffer.get(i).extensionNameString());
+        }
+
+        if(!supportedExtensions.containsAll(this.registry.getRequiredInstanceExtensions())) {
+            throw new RuntimeException("Required instance extension not found");
+        }
+
+        Set<String> enabledExtensions = new HashSet<>();
+        enabledExtensions.addAll(this.registry.getRequiredInstanceExtensions());
+        enabledExtensions.addAll(this.registry.getOptionalInstanceExtensions().stream().filter(supportedExtensions::contains).toList());
+
+        PointerBuffer extensionNames = stack.mallocPointer(enabledExtensions.size());
+        for(String extension : enabledExtensions) {
+            extensionNames.put(stack.UTF8(extension));
+        }
+
+        return extensionNames.rewind();
     }
 }

--- a/src/main/java/me/hydos/rosella/init/InstanceBuilder.java
+++ b/src/main/java/me/hydos/rosella/init/InstanceBuilder.java
@@ -1,0 +1,7 @@
+package me.hydos.rosella.init;
+
+public class InstanceBuilder {
+
+    public InstanceBuilder(InitializationRegistry registry) {
+    }
+}

--- a/src/main/java/me/hydos/rosella/init/InstanceBuilder.java
+++ b/src/main/java/me/hydos/rosella/init/InstanceBuilder.java
@@ -3,7 +3,6 @@ package me.hydos.rosella.init;
 import me.hydos.rosella.debug.MessageSeverity;
 import me.hydos.rosella.debug.MessageType;
 import me.hydos.rosella.debug.VulkanDebugCallback;
-import me.hydos.rosella.logging.DebugLogger;
 import me.hydos.rosella.util.VkUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;

--- a/src/main/java/me/hydos/rosella/init/VulkanInstance.java
+++ b/src/main/java/me/hydos/rosella/init/VulkanInstance.java
@@ -1,18 +1,30 @@
 package me.hydos.rosella.init;
 
 import me.hydos.rosella.logging.DebugLogger;
+import org.jetbrains.annotations.Nullable;
 import org.lwjgl.vulkan.VK10;
 import org.lwjgl.vulkan.VKCapabilitiesInstance;
+import org.lwjgl.vulkan.VkDebugUtilsMessengerCallbackDataEXT;
 import org.lwjgl.vulkan.VkInstance;
+
+import static org.lwjgl.vulkan.EXTDebugUtils.*;
 
 public class VulkanInstance {
 
     private final VkInstance instance;
     private final VulkanVersion version;
+    private final DebugUtilsCallback debugUtilsCallback;
 
     public VulkanInstance(VkInstance instance) {
         this.instance = instance;
         this.version = VulkanVersion.fromVersionNumber(instance.getCapabilities().apiVersion);
+        this.debugUtilsCallback = null;
+    }
+
+    public VulkanInstance(VkInstance instance, @Nullable DebugUtilsCallback callback) {
+        this.instance = instance;
+        this.version = VulkanVersion.fromVersionNumber(instance.getCapabilities().apiVersion);
+        this.debugUtilsCallback = callback;
     }
 
     public VkInstance getInstance() {
@@ -28,6 +40,45 @@ public class VulkanInstance {
     }
 
     public void destroy() {
+        if(this.debugUtilsCallback != null) {
+            this.debugUtilsCallback.destroy();
+        }
         VK10.vkDestroyInstance(this.instance, null);
+    }
+
+    public static class DebugUtilsCallback {
+        DebugLogger logger;
+
+        public DebugUtilsCallback(DebugLogger logger) {
+            this.logger = logger;
+        }
+
+        public int debugCallback(int severity, int messageType, long pCallbackData, long pUserData) {
+            VkDebugUtilsMessengerCallbackDataEXT callbackData = VkDebugUtilsMessengerCallbackDataEXT.create(pCallbackData);
+            String message = callbackData.pMessageString();
+
+            String msgSeverity = switch (severity) {
+                case VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT -> "VERBOSE";
+                case VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT -> "INFO";
+                case VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT -> "WARNING";
+                case VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT -> "ERROR";
+                default -> throw new IllegalStateException("Unexpected severity: " + severity);
+            };
+
+            if(this.logger == null) {
+                return VK10.VK_FALSE;
+            }
+
+            return switch (messageType) {
+                case VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT -> this.logger.logGeneral(message, msgSeverity);
+                case VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT -> this.logger.logValidation(message, msgSeverity);
+                case VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT -> this.logger.logPerformance(message, msgSeverity);
+                default -> this.logger.logUnknown(message, msgSeverity);
+            };
+        }
+
+        public void destroy() {
+            // Were creating the callback in the instance create info for now so nothing to do here.
+        }
     }
 }

--- a/src/main/java/me/hydos/rosella/init/VulkanInstance.java
+++ b/src/main/java/me/hydos/rosella/init/VulkanInstance.java
@@ -1,0 +1,32 @@
+package me.hydos.rosella.init;
+
+import org.lwjgl.vulkan.VK10;
+import org.lwjgl.vulkan.VKCapabilitiesInstance;
+import org.lwjgl.vulkan.VkInstance;
+
+public class VulkanInstance {
+
+    private final VkInstance instance;
+    private final VulkanVersion version;
+
+    public VulkanInstance(VkInstance instance) {
+        this.instance = instance;
+        this.version = VulkanVersion.fromVersionNumber(instance.getCapabilities().apiVersion);
+    }
+
+    public VkInstance getInstance() {
+        return this.instance;
+    }
+
+    public VKCapabilitiesInstance getCapabilities() {
+        return instance.getCapabilities();
+    }
+
+    public VulkanVersion getVersion() {
+        return this.version;
+    }
+
+    public void destroy() {
+        VK10.vkDestroyInstance(this.instance, null);
+    }
+}

--- a/src/main/java/me/hydos/rosella/init/VulkanInstance.java
+++ b/src/main/java/me/hydos/rosella/init/VulkanInstance.java
@@ -1,5 +1,6 @@
 package me.hydos.rosella.init;
 
+import me.hydos.rosella.logging.DebugLogger;
 import org.lwjgl.vulkan.VK10;
 import org.lwjgl.vulkan.VKCapabilitiesInstance;
 import org.lwjgl.vulkan.VkInstance;

--- a/src/main/java/me/hydos/rosella/init/VulkanVersion.java
+++ b/src/main/java/me/hydos/rosella/init/VulkanVersion.java
@@ -1,0 +1,47 @@
+package me.hydos.rosella.init;
+
+import org.lwjgl.vulkan.VK10;
+import org.lwjgl.vulkan.VK11;
+import org.lwjgl.vulkan.VK12;
+
+public enum VulkanVersion {
+    VULKAN_1_0(VK10.VK_API_VERSION_1_0),
+    VULKAN_1_1(VK11.VK_API_VERSION_1_1),
+    VULKAN_1_2(VK12.VK_API_VERSION_1_2);
+
+    private final int versionNumber;
+
+    VulkanVersion(int versionNumber) {
+        this.versionNumber = versionNumber;
+    }
+
+    public int getVersionNumber() {
+        return this.versionNumber;
+    }
+
+    @Override
+    public String toString() {
+        int major = VK10.VK_VERSION_MAJOR(this.versionNumber);
+        int minor = VK10.VK_VERSION_MINOR(this.versionNumber);
+        int patch = VK10.VK_VERSION_PATCH(this.versionNumber);
+
+        return "" + major + "." + minor + "." + patch;
+    }
+
+    /**
+     * Returns the vulkan version that matches the provided version number.
+     * If the version number is higher than any known version returns the highest known version.
+     *
+     * @param versionNumber The version number
+     * @return A version object matching the version number.
+     */
+    public static VulkanVersion fromVersionNumber(int versionNumber) {
+        if(versionNumber < VULKAN_1_1.getVersionNumber()) {
+            return VULKAN_1_0;
+        }
+        if(versionNumber < VULKAN_1_2.getVersionNumber()) {
+            return VULKAN_1_1;
+        }
+        return VULKAN_1_2;
+    }
+}

--- a/src/main/java/me/hydos/rosella/init/features/ApplicationFeature.java
+++ b/src/main/java/me/hydos/rosella/init/features/ApplicationFeature.java
@@ -1,5 +1,7 @@
 package me.hydos.rosella.init.features;
 
+import me.hydos.rosella.init.DeviceBuildConfigurator;
+import me.hydos.rosella.init.DeviceBuildInformation;
 import me.hydos.rosella.init.DeviceBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -104,7 +106,7 @@ public abstract class ApplicationFeature {
          * @param meta The DeviceMeta instance.
          * @return True if all dependant features are supported. False otherwise.
          */
-        protected boolean allDependenciesMet(DeviceBuilder.DeviceMeta meta) {
+        protected boolean allDependenciesMet(DeviceBuildInformation meta) {
             return dependencies.stream().allMatch(meta::isApplicationFeatureSupported);
         }
 
@@ -114,7 +116,7 @@ public abstract class ApplicationFeature {
          *
          * @param meta A DeviceMeta instance used to track information about the build process.
          */
-        public abstract void testFeatureSupport(DeviceBuilder.DeviceMeta meta);
+        public abstract void testFeatureSupport(DeviceBuildInformation meta);
 
         /**
          * Should configure the device to enable this feature.
@@ -122,6 +124,6 @@ public abstract class ApplicationFeature {
          * @param meta A DeviceMeta instance used to track information about the build process.
          * @return A object that can be used to return information to the application. Can be null.
          */
-        public abstract Object enableFeature(DeviceBuilder.DeviceMeta meta);
+        public abstract Object enableFeature(DeviceBuildConfigurator meta);
     }
 }

--- a/src/main/java/me/hydos/rosella/init/features/ApplicationFeature.java
+++ b/src/main/java/me/hydos/rosella/init/features/ApplicationFeature.java
@@ -1,5 +1,6 @@
-package me.hydos.rosella.init;
+package me.hydos.rosella.init.features;
 
+import me.hydos.rosella.init.DeviceBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -32,7 +33,7 @@ import java.util.*;
  *
  * <p>The default implementation of this class only validates that all dependencies are met and does not create any metadata.</p>
  */
-public class ApplicationFeature {
+public abstract class ApplicationFeature {
 
     public final String name;
     public final Set<String> dependencies;
@@ -67,9 +68,7 @@ public class ApplicationFeature {
     /**
      * @return A new instance to process a device
      */
-    public Instance createInstance() {
-        return new Instance();
-    }
+    public abstract Instance createInstance();
 
     @Override
     public final boolean equals(Object o) {
@@ -87,7 +86,7 @@ public class ApplicationFeature {
     /**
      * A class to process one device. A instance will never be reused.
      */
-    public class Instance {
+    public abstract class Instance {
 
         protected boolean canEnable;
 
@@ -115,9 +114,7 @@ public class ApplicationFeature {
          *
          * @param meta A DeviceMeta instance used to track information about the build process.
          */
-        public void testFeatureSupport(DeviceBuilder.DeviceMeta meta) {
-            this.canEnable = allDependenciesMet(meta);
-        }
+        public abstract void testFeatureSupport(DeviceBuilder.DeviceMeta meta);
 
         /**
          * Should configure the device to enable this feature.
@@ -125,8 +122,6 @@ public class ApplicationFeature {
          * @param meta A DeviceMeta instance used to track information about the build process.
          * @return A object that can be used to return information to the application. Can be null.
          */
-        public Object enableFeature(DeviceBuilder.DeviceMeta meta) {
-            return null;
-        }
+        public abstract Object enableFeature(DeviceBuilder.DeviceMeta meta);
     }
 }

--- a/src/main/java/me/hydos/rosella/init/features/ApplicationFeature.java
+++ b/src/main/java/me/hydos/rosella/init/features/ApplicationFeature.java
@@ -3,6 +3,7 @@ package me.hydos.rosella.init.features;
 import me.hydos.rosella.init.DeviceBuildConfigurator;
 import me.hydos.rosella.init.DeviceBuildInformation;
 import me.hydos.rosella.init.DeviceBuilder;
+import me.hydos.rosella.util.NamedID;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -37,16 +38,15 @@ import java.util.*;
  */
 public abstract class ApplicationFeature {
 
-    public final String name;
-    public final Set<String> dependencies;
+    public final NamedID name;
+    public final Set<NamedID> dependencies;
 
     /**
      * It is recommended to use the standard minecraft syntax for names. (i.e. "mod:name")
      *
      * @param name The name of this feature
      */
-    public ApplicationFeature(@NotNull String name) {
-        assert(!name.isEmpty());
+    public ApplicationFeature(@NotNull NamedID name) {
         this.name = name;
         this.dependencies = Collections.emptySet();
     }
@@ -57,8 +57,7 @@ public abstract class ApplicationFeature {
      * @param name The name of this feature
      * @param dependencies A list of dependencies
      */
-    public ApplicationFeature(@NotNull String name, @Nullable Collection<String> dependencies) {
-        assert(!name.isEmpty());
+    public ApplicationFeature(@NotNull NamedID name, @Nullable Collection<NamedID> dependencies) {
         this.name = name;
         if(dependencies != null) {
             this.dependencies = Set.copyOf(dependencies);
@@ -82,7 +81,7 @@ public abstract class ApplicationFeature {
 
     @Override
     public final int hashCode() {
-        return Objects.hash(name);
+        return name.hashCode();
     }
 
     /**
@@ -92,7 +91,7 @@ public abstract class ApplicationFeature {
 
         protected boolean canEnable;
 
-        public final String getFeatureName() {
+        public final NamedID getFeatureName() {
             return name;
         }
 

--- a/src/main/java/me/hydos/rosella/init/features/Compute.java
+++ b/src/main/java/me/hydos/rosella/init/features/Compute.java
@@ -1,0 +1,22 @@
+package me.hydos.rosella.init.features;
+
+import me.hydos.rosella.init.DeviceBuilder;
+import org.lwjgl.vulkan.VK10;
+
+/**
+ * Tests if at least one queue exists with graphics capabilities.
+ *
+ * Does not allocate any queues.
+ */
+public class Compute extends SimpleApplicationFeature {
+
+    public static final String NAME = "rosella:compute";
+
+    public Compute() {
+        super(NAME, Compute::canEnable, null);
+    }
+
+    private static boolean canEnable(DeviceBuilder.DeviceMeta meta) {
+        return meta.hasQueueWithFlags(VK10.VK_QUEUE_COMPUTE_BIT);
+    }
+}

--- a/src/main/java/me/hydos/rosella/init/features/Compute.java
+++ b/src/main/java/me/hydos/rosella/init/features/Compute.java
@@ -2,6 +2,7 @@ package me.hydos.rosella.init.features;
 
 import me.hydos.rosella.init.DeviceBuildInformation;
 import me.hydos.rosella.init.DeviceBuilder;
+import me.hydos.rosella.util.NamedID;
 import org.lwjgl.vulkan.VK10;
 
 /**
@@ -11,7 +12,7 @@ import org.lwjgl.vulkan.VK10;
  */
 public class Compute extends SimpleApplicationFeature {
 
-    public static final String NAME = "rosella:compute";
+    public static final NamedID NAME = new NamedID("rosella:compute");
 
     public Compute() {
         super(NAME, Compute::canEnable, null);

--- a/src/main/java/me/hydos/rosella/init/features/Compute.java
+++ b/src/main/java/me/hydos/rosella/init/features/Compute.java
@@ -1,5 +1,6 @@
 package me.hydos.rosella.init.features;
 
+import me.hydos.rosella.init.DeviceBuildInformation;
 import me.hydos.rosella.init.DeviceBuilder;
 import org.lwjgl.vulkan.VK10;
 
@@ -16,7 +17,7 @@ public class Compute extends SimpleApplicationFeature {
         super(NAME, Compute::canEnable, null);
     }
 
-    private static boolean canEnable(DeviceBuilder.DeviceMeta meta) {
-        return meta.hasQueueWithFlags(VK10.VK_QUEUE_COMPUTE_BIT);
+    private static boolean canEnable(DeviceBuildInformation meta) {
+        return !meta.findQueueFamilies(VK10.VK_QUEUE_COMPUTE_BIT, true).isEmpty();
     }
 }

--- a/src/main/java/me/hydos/rosella/init/features/DisplayGLFW.java
+++ b/src/main/java/me/hydos/rosella/init/features/DisplayGLFW.java
@@ -3,6 +3,7 @@ package me.hydos.rosella.init.features;
 import me.hydos.rosella.device.VulkanQueue;
 import me.hydos.rosella.init.DeviceBuildConfigurator;
 import me.hydos.rosella.init.DeviceBuildInformation;
+import me.hydos.rosella.util.NamedID;
 
 import java.util.concurrent.Future;
 
@@ -13,7 +14,7 @@ import java.util.concurrent.Future;
  */
 public class DisplayGLFW extends ApplicationFeature {
 
-    public static final String NAME = "rosella:display_glfw";
+    public static final NamedID NAME = new NamedID("rosella:display_glfw");
 
     public DisplayGLFW() {
         super(NAME);

--- a/src/main/java/me/hydos/rosella/init/features/DisplayGLFW.java
+++ b/src/main/java/me/hydos/rosella/init/features/DisplayGLFW.java
@@ -24,13 +24,6 @@ public class DisplayGLFW extends ApplicationFeature {
         return new DisplayGLFWInstance();
     }
 
-    public static Meta getMetaObject(Object o) {
-        if(!(o instanceof Meta)) {
-            throw new RuntimeException("Meta object could not be cast to QueueRequest");
-        }
-        return (Meta) o;
-    }
-
     public class DisplayGLFWInstance extends ApplicationFeature.Instance {
 
         @Override

--- a/src/main/java/me/hydos/rosella/init/features/DisplayGLFW.java
+++ b/src/main/java/me/hydos/rosella/init/features/DisplayGLFW.java
@@ -1,7 +1,8 @@
 package me.hydos.rosella.init.features;
 
 import me.hydos.rosella.device.VulkanQueue;
-import me.hydos.rosella.init.DeviceBuilder;
+import me.hydos.rosella.init.DeviceBuildConfigurator;
+import me.hydos.rosella.init.DeviceBuildInformation;
 
 import java.util.concurrent.Future;
 
@@ -33,12 +34,12 @@ public class DisplayGLFW extends ApplicationFeature {
     public class DisplayGLFWInstance extends ApplicationFeature.Instance {
 
         @Override
-        public void testFeatureSupport(DeviceBuilder.DeviceMeta meta) {
+        public void testFeatureSupport(DeviceBuildInformation meta) {
 
         }
 
         @Override
-        public Object enableFeature(DeviceBuilder.DeviceMeta meta) {
+        public Object enableFeature(DeviceBuildConfigurator meta) {
             return null;
         }
     }

--- a/src/main/java/me/hydos/rosella/init/features/DisplayGLFW.java
+++ b/src/main/java/me/hydos/rosella/init/features/DisplayGLFW.java
@@ -1,0 +1,48 @@
+package me.hydos.rosella.init.features;
+
+import me.hydos.rosella.device.VulkanQueue;
+import me.hydos.rosella.init.DeviceBuilder;
+
+import java.util.concurrent.Future;
+
+/**
+ * Tests for display capabilities and allocates a display queue.
+ *
+ * The returned meta object will be the queue request.
+ */
+public class DisplayGLFW extends ApplicationFeature {
+
+    public static final String NAME = "rosella:display_glfw";
+
+    public DisplayGLFW() {
+        super(NAME);
+    }
+
+    @Override
+    public DisplayGLFWInstance createInstance() {
+        return new DisplayGLFWInstance();
+    }
+
+    public static Meta getMetaObject(Object o) {
+        if(!(o instanceof Meta)) {
+            throw new RuntimeException("Meta object could not be cast to QueueRequest");
+        }
+        return (Meta) o;
+    }
+
+    public class DisplayGLFWInstance extends ApplicationFeature.Instance {
+
+        @Override
+        public void testFeatureSupport(DeviceBuilder.DeviceMeta meta) {
+
+        }
+
+        @Override
+        public Object enableFeature(DeviceBuilder.DeviceMeta meta) {
+            return null;
+        }
+    }
+
+    public record Meta(Future<VulkanQueue> queue) {
+    }
+}

--- a/src/main/java/me/hydos/rosella/init/features/Graphics.java
+++ b/src/main/java/me/hydos/rosella/init/features/Graphics.java
@@ -1,6 +1,6 @@
 package me.hydos.rosella.init.features;
 
-import me.hydos.rosella.init.DeviceBuilder;
+import me.hydos.rosella.init.DeviceBuildInformation;
 import org.lwjgl.vulkan.VK10;
 
 /**
@@ -16,7 +16,7 @@ public class Graphics extends SimpleApplicationFeature {
         super(NAME, Graphics::canEnable, null);
     }
 
-    private static boolean canEnable(DeviceBuilder.DeviceMeta meta) {
-        return meta.hasQueueWithFlags(VK10.VK_QUEUE_GRAPHICS_BIT);
+    private static boolean canEnable(DeviceBuildInformation meta) {
+        return !meta.findQueueFamilies(VK10.VK_QUEUE_GRAPHICS_BIT, true).isEmpty();
     }
 }

--- a/src/main/java/me/hydos/rosella/init/features/Graphics.java
+++ b/src/main/java/me/hydos/rosella/init/features/Graphics.java
@@ -1,0 +1,22 @@
+package me.hydos.rosella.init.features;
+
+import me.hydos.rosella.init.DeviceBuilder;
+import org.lwjgl.vulkan.VK10;
+
+/**
+ * Tests if at least one queue exists with graphics capabilities.
+ *
+ * Does not allocate any queues.
+ */
+public class Graphics extends SimpleApplicationFeature {
+
+    public static final String NAME = "rosella:graphics";
+
+    public Graphics() {
+        super(NAME, Graphics::canEnable, null);
+    }
+
+    private static boolean canEnable(DeviceBuilder.DeviceMeta meta) {
+        return meta.hasQueueWithFlags(VK10.VK_QUEUE_GRAPHICS_BIT);
+    }
+}

--- a/src/main/java/me/hydos/rosella/init/features/Graphics.java
+++ b/src/main/java/me/hydos/rosella/init/features/Graphics.java
@@ -1,6 +1,7 @@
 package me.hydos.rosella.init.features;
 
 import me.hydos.rosella.init.DeviceBuildInformation;
+import me.hydos.rosella.util.NamedID;
 import org.lwjgl.vulkan.VK10;
 
 /**
@@ -10,7 +11,7 @@ import org.lwjgl.vulkan.VK10;
  */
 public class Graphics extends SimpleApplicationFeature {
 
-    public static final String NAME = "rosella:graphics";
+    public static final NamedID NAME = new NamedID("rosella:graphics");
 
     public Graphics() {
         super(NAME, Graphics::canEnable, null);

--- a/src/main/java/me/hydos/rosella/init/features/RosellaLegacy.java
+++ b/src/main/java/me/hydos/rosella/init/features/RosellaLegacy.java
@@ -1,6 +1,7 @@
 package me.hydos.rosella.init.features;
 
 import me.hydos.rosella.device.QueueFamilyIndices;
+import me.hydos.rosella.device.VulkanDevice;
 import me.hydos.rosella.device.VulkanQueue;
 import me.hydos.rosella.init.DeviceBuildConfigurator;
 import me.hydos.rosella.init.DeviceBuildInformation;
@@ -11,6 +12,7 @@ import me.hydos.rosella.vkobjects.VkCommon;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.vulkan.KHRSwapchain;
 
+import javax.print.attribute.standard.MediaSize;
 import java.util.concurrent.Future;
 
 /**
@@ -72,7 +74,13 @@ public class RosellaLegacy extends ApplicationFeature {
         }
     }
 
-    public static RosellaLegacyFeatures getMetaObject(Object o) {
+    public static RosellaLegacyFeatures getMetadata(VulkanDevice device) {
+        Object o = device.getFeatureMeta(NAME);
+
+        if(o == null) {
+            return null;
+        }
+
         if(!(o instanceof RosellaLegacyFeatures)) {
             throw new RuntimeException("Meta object could not be cast to RosellaLegacyFeatures");
         }

--- a/src/main/java/me/hydos/rosella/init/features/RosellaLegacy.java
+++ b/src/main/java/me/hydos/rosella/init/features/RosellaLegacy.java
@@ -7,6 +7,7 @@ import me.hydos.rosella.init.DeviceBuildConfigurator;
 import me.hydos.rosella.init.DeviceBuildInformation;
 import me.hydos.rosella.render.swapchain.Swapchain;
 import me.hydos.rosella.render.swapchain.SwapchainSupportDetails;
+import me.hydos.rosella.util.NamedID;
 import me.hydos.rosella.util.VkUtils;
 import me.hydos.rosella.vkobjects.VkCommon;
 import org.lwjgl.system.MemoryStack;
@@ -20,7 +21,7 @@ import java.util.concurrent.Future;
  */
 public class RosellaLegacy extends ApplicationFeature {
 
-    public static final String NAME = "rosella:legacy";
+    public static final NamedID NAME = new NamedID("rosella:legacy");
 
     private final VkCommon common;
 

--- a/src/main/java/me/hydos/rosella/init/features/RosellaLegacy.java
+++ b/src/main/java/me/hydos/rosella/init/features/RosellaLegacy.java
@@ -2,7 +2,8 @@ package me.hydos.rosella.init.features;
 
 import me.hydos.rosella.device.QueueFamilyIndices;
 import me.hydos.rosella.device.VulkanQueue;
-import me.hydos.rosella.init.DeviceBuilder;
+import me.hydos.rosella.init.DeviceBuildConfigurator;
+import me.hydos.rosella.init.DeviceBuildInformation;
 import me.hydos.rosella.render.swapchain.Swapchain;
 import me.hydos.rosella.render.swapchain.SwapchainSupportDetails;
 import me.hydos.rosella.util.VkUtils;
@@ -36,28 +37,28 @@ public class RosellaLegacy extends ApplicationFeature {
         private QueueFamilyIndices indices = null;
 
         @Override
-        public void testFeatureSupport(DeviceBuilder.DeviceMeta meta) {
+        public void testFeatureSupport(DeviceBuildInformation meta) {
             canEnable = false;
 
-            indices = VkUtils.findQueueFamilies(meta.physicalDevice, common.surface);
+            indices = VkUtils.findQueueFamilies(meta.getPhysicalDevice(), common.surface);
 
             try (MemoryStack stack = MemoryStack.stackPush()) {
                 boolean swapChainAdequate;
                 boolean featureSupported;
 
-                SwapchainSupportDetails swapchainSupport = Swapchain.Companion.querySwapchainSupport(meta.physicalDevice, stack, common.surface);
+                SwapchainSupportDetails swapchainSupport = Swapchain.Companion.querySwapchainSupport(meta.getPhysicalDevice(), stack, common.surface);
                 swapChainAdequate = swapchainSupport.formats.hasRemaining() && swapchainSupport.presentModes.hasRemaining();
                 featureSupported =
-                        meta.availableFeatures.samplerAnisotropy() &&
-                        meta.availableFeatures.depthClamp() &&
-                        meta.availableFeatures.depthBounds();
+                        meta.getPhysicalDeviceFeatures().samplerAnisotropy() &&
+                        meta.getPhysicalDeviceFeatures().depthClamp() &&
+                        meta.getPhysicalDeviceFeatures().depthBounds();
 
-                canEnable = indices.isComplete() && swapChainAdequate && featureSupported && meta.isExtensionSupported(KHRSwapchain.VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+                canEnable = indices.isComplete() && swapChainAdequate && featureSupported && meta.isExtensionAvailable(KHRSwapchain.VK_KHR_SWAPCHAIN_EXTENSION_NAME);
             }
         }
 
         @Override
-        public Object enableFeature(DeviceBuilder.DeviceMeta meta) {
+        public Object enableFeature(DeviceBuildConfigurator meta) {
             meta.configureDeviceFeatures()
                     .samplerAnisotropy(true)
                     .depthClamp(true)

--- a/src/main/java/me/hydos/rosella/init/features/RosellaLegacy.java
+++ b/src/main/java/me/hydos/rosella/init/features/RosellaLegacy.java
@@ -1,0 +1,83 @@
+package me.hydos.rosella.init.features;
+
+import me.hydos.rosella.device.QueueFamilyIndices;
+import me.hydos.rosella.device.VulkanQueue;
+import me.hydos.rosella.init.DeviceBuilder;
+import me.hydos.rosella.render.swapchain.Swapchain;
+import me.hydos.rosella.render.swapchain.SwapchainSupportDetails;
+import me.hydos.rosella.util.VkUtils;
+import me.hydos.rosella.vkobjects.VkCommon;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.KHRSwapchain;
+
+import java.util.concurrent.Future;
+
+/**
+ * Configures the device to run the legacy rosella engine.
+ */
+public class RosellaLegacy extends ApplicationFeature {
+
+    public static final String NAME = "rosella:legacy";
+
+    private final VkCommon common;
+
+    public RosellaLegacy(VkCommon common) {
+        super(NAME);
+        this.common = common;
+    }
+
+    @Override
+    public RosellaLegacyInstance createInstance() {
+        return new RosellaLegacyInstance();
+    }
+
+    public class RosellaLegacyInstance extends ApplicationFeature.Instance {
+
+        private QueueFamilyIndices indices = null;
+
+        @Override
+        public void testFeatureSupport(DeviceBuilder.DeviceMeta meta) {
+            canEnable = false;
+
+            indices = VkUtils.findQueueFamilies(meta.physicalDevice, common.surface);
+
+            try (MemoryStack stack = MemoryStack.stackPush()) {
+                boolean swapChainAdequate;
+                boolean featureSupported;
+
+                SwapchainSupportDetails swapchainSupport = Swapchain.Companion.querySwapchainSupport(meta.physicalDevice, stack, common.surface);
+                swapChainAdequate = swapchainSupport.formats.hasRemaining() && swapchainSupport.presentModes.hasRemaining();
+                featureSupported =
+                        meta.availableFeatures.samplerAnisotropy() &&
+                        meta.availableFeatures.depthClamp() &&
+                        meta.availableFeatures.depthBounds();
+
+                canEnable = indices.isComplete() && swapChainAdequate && featureSupported && meta.isExtensionSupported(KHRSwapchain.VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+            }
+        }
+
+        @Override
+        public Object enableFeature(DeviceBuilder.DeviceMeta meta) {
+            meta.configureDeviceFeatures()
+                    .samplerAnisotropy(true)
+                    .depthClamp(true)
+                    .depthBounds(true);
+
+            meta.enableExtension(KHRSwapchain.VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+
+            Future<VulkanQueue> graphicsRequest = meta.addQueueRequest(this.indices.graphicsFamily);
+            Future<VulkanQueue> presentRequest = meta.addQueueRequest(this.indices.presentFamily);
+            return new RosellaLegacyFeatures(graphicsRequest, presentRequest, this.indices);
+        }
+    }
+
+    public static RosellaLegacyFeatures getMetaObject(Object o) {
+        if(!(o instanceof RosellaLegacyFeatures)) {
+            throw new RuntimeException("Meta object could not be cast to RosellaLegacyFeatures");
+        }
+        return (RosellaLegacyFeatures) o;
+    }
+
+    public record RosellaLegacyFeatures(Future<VulkanQueue> graphicsQueue, Future<VulkanQueue> presentQueue, QueueFamilyIndices indices) {
+    }
+}

--- a/src/main/java/me/hydos/rosella/init/features/SimpleApplicationFeature.java
+++ b/src/main/java/me/hydos/rosella/init/features/SimpleApplicationFeature.java
@@ -1,6 +1,7 @@
 package me.hydos.rosella.init.features;
 
-import me.hydos.rosella.init.DeviceBuilder;
+import me.hydos.rosella.init.DeviceBuildConfigurator;
+import me.hydos.rosella.init.DeviceBuildInformation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,18 +17,18 @@ import java.util.function.Function;
  */
 public class SimpleApplicationFeature extends ApplicationFeature {
 
-    protected final Function<DeviceBuilder.DeviceMeta, Boolean> testFunc;
-    protected final Function<DeviceBuilder.DeviceMeta, Void> enableFunc;
+    protected final Function<DeviceBuildInformation, Boolean> testFunc;
+    protected final Function<DeviceBuildConfigurator, Void> enableFunc;
 
     public SimpleApplicationFeature(@NotNull String name, @NotNull Collection<String> dependencies) {
         this(name, dependencies, null, null);
     }
 
-    public SimpleApplicationFeature(@NotNull String name, @Nullable Function<DeviceBuilder.DeviceMeta, Boolean> testFunc, @Nullable Function<DeviceBuilder.DeviceMeta, Void> enableFunc) {
+    public SimpleApplicationFeature(@NotNull String name, @Nullable Function<DeviceBuildInformation, Boolean> testFunc, @Nullable Function<DeviceBuildConfigurator, Void> enableFunc) {
         this(name, null, testFunc, enableFunc);
     }
 
-    public SimpleApplicationFeature(@NotNull String name, @Nullable Collection<String> dependencies, @Nullable Function<DeviceBuilder.DeviceMeta, Boolean> testFunc, @Nullable Function<DeviceBuilder.DeviceMeta, Void> enableFunc) {
+    public SimpleApplicationFeature(@NotNull String name, @Nullable Collection<String> dependencies, @Nullable Function<DeviceBuildInformation, Boolean> testFunc, @Nullable Function<DeviceBuildConfigurator, Void> enableFunc) {
         super(name, dependencies);
         this.testFunc = testFunc;
         this.enableFunc = enableFunc;
@@ -40,7 +41,7 @@ public class SimpleApplicationFeature extends ApplicationFeature {
 
     protected class SimpleInstance extends ApplicationFeature.Instance {
         @Override
-        public void testFeatureSupport(DeviceBuilder.DeviceMeta meta) {
+        public void testFeatureSupport(DeviceBuildInformation meta) {
             this.canEnable = false;
             if(allDependenciesMet(meta)) {
                 if(testFunc != null) {
@@ -52,7 +53,7 @@ public class SimpleApplicationFeature extends ApplicationFeature {
         }
 
         @Override
-        public Object enableFeature(DeviceBuilder.DeviceMeta meta) {
+        public Object enableFeature(DeviceBuildConfigurator meta) {
             if(enableFunc != null) {
                 enableFunc.apply(meta);
             }

--- a/src/main/java/me/hydos/rosella/init/features/SimpleApplicationFeature.java
+++ b/src/main/java/me/hydos/rosella/init/features/SimpleApplicationFeature.java
@@ -2,6 +2,7 @@ package me.hydos.rosella.init.features;
 
 import me.hydos.rosella.init.DeviceBuildConfigurator;
 import me.hydos.rosella.init.DeviceBuildInformation;
+import me.hydos.rosella.util.NamedID;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,15 +21,15 @@ public class SimpleApplicationFeature extends ApplicationFeature {
     protected final Function<DeviceBuildInformation, Boolean> testFunc;
     protected final Function<DeviceBuildConfigurator, Void> enableFunc;
 
-    public SimpleApplicationFeature(@NotNull String name, @NotNull Collection<String> dependencies) {
+    public SimpleApplicationFeature(@NotNull NamedID name, @NotNull Collection<NamedID> dependencies) {
         this(name, dependencies, null, null);
     }
 
-    public SimpleApplicationFeature(@NotNull String name, @Nullable Function<DeviceBuildInformation, Boolean> testFunc, @Nullable Function<DeviceBuildConfigurator, Void> enableFunc) {
+    public SimpleApplicationFeature(@NotNull NamedID name, @Nullable Function<DeviceBuildInformation, Boolean> testFunc, @Nullable Function<DeviceBuildConfigurator, Void> enableFunc) {
         this(name, null, testFunc, enableFunc);
     }
 
-    public SimpleApplicationFeature(@NotNull String name, @Nullable Collection<String> dependencies, @Nullable Function<DeviceBuildInformation, Boolean> testFunc, @Nullable Function<DeviceBuildConfigurator, Void> enableFunc) {
+    public SimpleApplicationFeature(@NotNull NamedID name, @Nullable Collection<NamedID> dependencies, @Nullable Function<DeviceBuildInformation, Boolean> testFunc, @Nullable Function<DeviceBuildConfigurator, Void> enableFunc) {
         super(name, dependencies);
         this.testFunc = testFunc;
         this.enableFunc = enableFunc;

--- a/src/main/java/me/hydos/rosella/init/features/SimpleApplicationFeature.java
+++ b/src/main/java/me/hydos/rosella/init/features/SimpleApplicationFeature.java
@@ -1,0 +1,62 @@
+package me.hydos.rosella.init.features;
+
+import me.hydos.rosella.init.DeviceBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+/**
+ * A class to create simple features whose test and enable functions do not need to keep any data or for dependency only
+ * features.
+ *
+ * If a test function is provided the feature is only enabled if all dependencies are met and the test function returns true.
+ * If no test function is provided the feature will be enabled if all dependencies are met.
+ */
+public class SimpleApplicationFeature extends ApplicationFeature {
+
+    protected final Function<DeviceBuilder.DeviceMeta, Boolean> testFunc;
+    protected final Function<DeviceBuilder.DeviceMeta, Void> enableFunc;
+
+    public SimpleApplicationFeature(@NotNull String name, @NotNull Collection<String> dependencies) {
+        this(name, dependencies, null, null);
+    }
+
+    public SimpleApplicationFeature(@NotNull String name, @Nullable Function<DeviceBuilder.DeviceMeta, Boolean> testFunc, @Nullable Function<DeviceBuilder.DeviceMeta, Void> enableFunc) {
+        this(name, null, testFunc, enableFunc);
+    }
+
+    public SimpleApplicationFeature(@NotNull String name, @Nullable Collection<String> dependencies, @Nullable Function<DeviceBuilder.DeviceMeta, Boolean> testFunc, @Nullable Function<DeviceBuilder.DeviceMeta, Void> enableFunc) {
+        super(name, dependencies);
+        this.testFunc = testFunc;
+        this.enableFunc = enableFunc;
+    }
+
+    @Override
+    public SimpleInstance createInstance() {
+        return new SimpleInstance();
+    }
+
+    protected class SimpleInstance extends ApplicationFeature.Instance {
+        @Override
+        public void testFeatureSupport(DeviceBuilder.DeviceMeta meta) {
+            this.canEnable = false;
+            if(allDependenciesMet(meta)) {
+                if(testFunc != null) {
+                    this.canEnable = testFunc.apply(meta);
+                } else {
+                    this.canEnable = true;
+                }
+            }
+        }
+
+        @Override
+        public Object enableFeature(DeviceBuilder.DeviceMeta meta) {
+            if(enableFunc != null) {
+                enableFunc.apply(meta);
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/me/hydos/rosella/memory/BufferInfo.java
+++ b/src/main/java/me/hydos/rosella/memory/BufferInfo.java
@@ -1,10 +1,10 @@
 package me.hydos.rosella.memory;
 
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 
 public record BufferInfo(long buffer, long allocation) implements MemoryCloseable {
     @Override
-    public void free(VulkanDevice device, Memory memory) {
+    public void free(LegacyVulkanDevice device, Memory memory) {
         memory.freeBuffer(this);
     }
 }

--- a/src/main/java/me/hydos/rosella/memory/ManagedBuffer.java
+++ b/src/main/java/me/hydos/rosella/memory/ManagedBuffer.java
@@ -1,13 +1,13 @@
 package me.hydos.rosella.memory;
 
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 
 import java.nio.Buffer;
 
 public record ManagedBuffer<T extends Buffer>(T buffer, boolean freeable) implements MemoryCloseable {
 
     @Override
-    public void free(VulkanDevice device, Memory memory) {
+    public void free(LegacyVulkanDevice device, Memory memory) {
         if (freeable) {
             memory.freeDirectBufferAsync(buffer);
         }

--- a/src/main/java/me/hydos/rosella/memory/Memory.java
+++ b/src/main/java/me/hydos/rosella/memory/Memory.java
@@ -4,7 +4,7 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.longs.LongSets;
 import me.hydos.rosella.Rosella;
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.render.material.PipelineInfo;
 import me.hydos.rosella.render.renderer.Renderer;
 import me.hydos.rosella.render.texture.TextureImage;
@@ -26,7 +26,6 @@ import java.nio.LongBuffer;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -211,7 +210,7 @@ public abstract class Memory {
     /**
      * Copies a buffer from one place to another. usually used to copy a staging buffer into GPU mem
      */
-    public void copyBuffer(long srcBuffer, long dstBuffer, int size, Renderer renderer, VulkanDevice device) {
+    public void copyBuffer(long srcBuffer, long dstBuffer, int size, Renderer renderer, LegacyVulkanDevice device) {
         try (MemoryStack stack = stackPush()) {
             PointerBuffer pCommandBuffer = stack.mallocPointer(1);
             VkCommandBuffer commandBuffer = renderer.beginCmdBuffer(pCommandBuffer, device);

--- a/src/main/java/me/hydos/rosella/memory/MemoryCloseable.java
+++ b/src/main/java/me/hydos/rosella/memory/MemoryCloseable.java
@@ -1,10 +1,10 @@
 package me.hydos.rosella.memory;
 
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 
 /**
  * Used to safely close memory when an object wants to be de-allocated.
  */
 public interface MemoryCloseable {
-    void free(VulkanDevice device, Memory memory);
+    void free(LegacyVulkanDevice device, Memory memory);
 }

--- a/src/main/java/me/hydos/rosella/render/descriptorsets/DescriptorSets.java
+++ b/src/main/java/me/hydos/rosella/render/descriptorsets/DescriptorSets.java
@@ -1,7 +1,7 @@
 package me.hydos.rosella.render.descriptorsets;
 
 import it.unimi.dsi.fastutil.longs.LongArrayList;
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.memory.ManagedBuffer;
 import me.hydos.rosella.memory.Memory;
 import me.hydos.rosella.memory.MemoryCloseable;
@@ -24,7 +24,7 @@ public class DescriptorSets implements MemoryCloseable {
     }
 
     @Override
-    public void free(VulkanDevice device, Memory memory) {
+    public void free(LegacyVulkanDevice device, Memory memory) {
         LongBuffer buffer = MemoryUtil.memAllocLong(descriptorSets.size());
         for (long descriptorSet : descriptorSets) {
             if (descriptorSet != 0L) {

--- a/src/main/java/me/hydos/rosella/render/info/InstanceInfo.java
+++ b/src/main/java/me/hydos/rosella/render/info/InstanceInfo.java
@@ -1,7 +1,7 @@
 package me.hydos.rosella.render.info;
 
 import me.hydos.rosella.Rosella;
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.memory.Memory;
 import me.hydos.rosella.memory.MemoryCloseable;
 import me.hydos.rosella.render.material.Material;
@@ -15,7 +15,7 @@ public record InstanceInfo(Ubo ubo,
                            Material material) implements MemoryCloseable {
 
     @Override
-    public void free(VulkanDevice device, Memory memory) {
+    public void free(LegacyVulkanDevice device, Memory memory) {
         ubo.free(device, memory);
         material.getShader().getDescriptorManager().freeDescriptorSets(ubo.getDescriptors());
     }

--- a/src/main/java/me/hydos/rosella/render/info/RenderInfo.java
+++ b/src/main/java/me/hydos/rosella/render/info/RenderInfo.java
@@ -1,13 +1,13 @@
 package me.hydos.rosella.render.info;
 
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.memory.BufferInfo;
 import me.hydos.rosella.memory.Memory;
 import me.hydos.rosella.memory.MemoryCloseable;
 
 public record RenderInfo(BufferInfo vertexBuffer, BufferInfo indexBuffer, int indexCount) implements MemoryCloseable {
     @Override
-    public void free(VulkanDevice device, Memory memory) {
+    public void free(LegacyVulkanDevice device, Memory memory) {
         memory.freeBuffer(vertexBuffer);
         memory.freeBuffer(indexBuffer);
     }

--- a/src/main/java/me/hydos/rosella/render/material/PipelineInfo.java
+++ b/src/main/java/me/hydos/rosella/render/material/PipelineInfo.java
@@ -1,13 +1,13 @@
 package me.hydos.rosella.render.material;
 
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.memory.Memory;
 import me.hydos.rosella.memory.MemoryCloseable;
 
 public record PipelineInfo(long pipelineLayout, long graphicsPipeline) implements MemoryCloseable {
 
     @Override
-    public void free(VulkanDevice device, Memory memory) {
+    public void free(LegacyVulkanDevice device, Memory memory) {
         memory.freePipeline(this);
     }
 }

--- a/src/main/java/me/hydos/rosella/render/material/PipelineManager.java
+++ b/src/main/java/me/hydos/rosella/render/material/PipelineManager.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import me.hydos.rosella.Rosella;
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.render.Topology;
 import me.hydos.rosella.render.material.state.StateInfo;
 import me.hydos.rosella.render.renderer.Renderer;
@@ -83,7 +83,7 @@ public class PipelineManager {
     /**
      * Creates a new pipeline
      */
-    private PipelineInfo createPipeline(VulkanDevice device, Swapchain swapchain, RenderPass renderPass, Long descriptorSetLayout, int polygonMode, ShaderProgram shader, Topology topology, VertexFormat vertexFormat, StateInfo stateInfo) {
+    private PipelineInfo createPipeline(LegacyVulkanDevice device, Swapchain swapchain, RenderPass renderPass, Long descriptorSetLayout, int polygonMode, ShaderProgram shader, Topology topology, VertexFormat vertexFormat, StateInfo stateInfo) {
         long pipelineLayout;
         long graphicsPipeline;
 

--- a/src/main/java/me/hydos/rosella/render/renderer/Renderer.java
+++ b/src/main/java/me/hydos/rosella/render/renderer/Renderer.java
@@ -5,7 +5,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import me.hydos.rosella.Rosella;
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.device.VulkanQueues;
 import me.hydos.rosella.display.Display;
 import me.hydos.rosella.memory.Memory;
@@ -106,7 +106,7 @@ public class Renderer {
         createSyncObjects();
     }
 
-    public VkCommandBuffer beginCmdBuffer(PointerBuffer pCommandBuffer, VulkanDevice device) {
+    public VkCommandBuffer beginCmdBuffer(PointerBuffer pCommandBuffer, LegacyVulkanDevice device) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo allocInfo = VkCommandBufferAllocateInfo.callocStack(stack)
                     .sType(VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO)
@@ -242,7 +242,7 @@ public class Renderer {
         swapchain.free(rosella.common.device.rawDevice);
     }
 
-    public void clearCommandBuffers(VulkanDevice device) {
+    public void clearCommandBuffers(LegacyVulkanDevice device) {
         if (commandBuffers.size() != 0) {
             vkFreeCommandBuffers(device.rawDevice, commandPool, Memory.asPointerBuffer(commandBuffers));
             commandBuffers.clear();

--- a/src/main/java/me/hydos/rosella/render/renderer/Renderer.java
+++ b/src/main/java/me/hydos/rosella/render/renderer/Renderer.java
@@ -72,7 +72,7 @@ public class Renderer {
         this.rosella = rosella;
         this.common = rosella.common;
 
-        this.queues = new VulkanQueues(common);
+        this.queues = common.queues;
         this.depthBuffer = new DepthBuffer();
 
         VkUtils.createCommandPool(common.device, this, common.surface);

--- a/src/main/java/me/hydos/rosella/render/swapchain/RenderPass.java
+++ b/src/main/java/me/hydos/rosella/render/swapchain/RenderPass.java
@@ -1,6 +1,6 @@
 package me.hydos.rosella.render.swapchain;
 
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.render.renderer.Renderer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.vulkan.*;
@@ -15,7 +15,7 @@ public class RenderPass {
 
     private final long renderPass;
 
-    public RenderPass(VulkanDevice device, Swapchain swapchain, Renderer renderer) {
+    public RenderPass(LegacyVulkanDevice device, Swapchain swapchain, Renderer renderer) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkAttachmentDescription.Buffer attachments = VkAttachmentDescription.callocStack(2, stack);
             VkAttachmentReference.Buffer attachmentRefs = VkAttachmentReference.callocStack(2, stack);

--- a/src/main/java/me/hydos/rosella/render/texture/TextureImage.java
+++ b/src/main/java/me/hydos/rosella/render/texture/TextureImage.java
@@ -1,6 +1,6 @@
 package me.hydos.rosella.render.texture;
 
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.memory.Memory;
 import me.hydos.rosella.memory.MemoryCloseable;
 
@@ -57,7 +57,7 @@ public class TextureImage implements MemoryCloseable {
     }
 
     @Override
-    public void free(VulkanDevice device, Memory memory) {
+    public void free(LegacyVulkanDevice device, Memory memory) {
         memory.freeImage(this);
     }
 }

--- a/src/main/java/me/hydos/rosella/render/vertex/BufferVertexConsumer.java
+++ b/src/main/java/me/hydos/rosella/render/vertex/BufferVertexConsumer.java
@@ -1,13 +1,5 @@
 package me.hydos.rosella.render.vertex;
 
-import me.hydos.rosella.device.VulkanDevice;
-import me.hydos.rosella.memory.Memory;
-
-import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-
 // FIXME redo this whole class honestly
 //public final class BufferVertexConsumer {
 //    private final VertexFormat format;

--- a/src/main/java/me/hydos/rosella/scene/object/RenderObject.java
+++ b/src/main/java/me/hydos/rosella/scene/object/RenderObject.java
@@ -1,7 +1,7 @@
 package me.hydos.rosella.scene.object;
 
 import me.hydos.rosella.Rosella;
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.memory.ManagedBuffer;
 import me.hydos.rosella.memory.Memory;
 import me.hydos.rosella.render.info.InstanceInfo;
@@ -88,7 +88,7 @@ public class RenderObject implements Renderable {
     }
 
     @Override
-    public void free(VulkanDevice device, Memory memory) {
+    public void free(LegacyVulkanDevice device, Memory memory) {
         instanceInfo.free(device, memory);
         try {
             renderInfo.get().free(device, memory);

--- a/src/main/java/me/hydos/rosella/scene/object/Renderable.java
+++ b/src/main/java/me/hydos/rosella/scene/object/Renderable.java
@@ -1,8 +1,6 @@
 package me.hydos.rosella.scene.object;
 
 import me.hydos.rosella.Rosella;
-import me.hydos.rosella.device.VulkanDevice;
-import me.hydos.rosella.memory.Memory;
 import me.hydos.rosella.memory.MemoryCloseable;
 import me.hydos.rosella.render.info.InstanceInfo;
 import me.hydos.rosella.render.info.RenderInfo;

--- a/src/main/java/me/hydos/rosella/ubo/DescriptorManager.java
+++ b/src/main/java/me/hydos/rosella/ubo/DescriptorManager.java
@@ -1,6 +1,6 @@
 package me.hydos.rosella.ubo;
 
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.memory.Memory;
 import me.hydos.rosella.render.descriptorsets.DescriptorSets;
 import me.hydos.rosella.render.shader.ShaderProgram;
@@ -18,7 +18,7 @@ public class DescriptorManager {
     private static final Logger LOGGER = LogManager.getLogger("DescriptorManager");
     private final ShaderProgram program;
     private final Swapchain swapchain;
-    private final VulkanDevice device;
+    private final LegacyVulkanDevice device;
     private final Memory memory;
     private final int maxObjects;
     private int activeDescriptorCount;
@@ -29,7 +29,7 @@ public class DescriptorManager {
      * @param maxObjects the max amount of DescriptorSet's
      * @param program    the {@link ShaderProgram} to base it off
      */
-    public DescriptorManager(int maxObjects, ShaderProgram program, Swapchain swapchain, VulkanDevice device, Memory memory) {
+    public DescriptorManager(int maxObjects, ShaderProgram program, Swapchain swapchain, LegacyVulkanDevice device, Memory memory) {
         this.maxObjects = maxObjects;
         this.program = program;
         this.swapchain = swapchain;

--- a/src/main/java/me/hydos/rosella/util/NamedID.java
+++ b/src/main/java/me/hydos/rosella/util/NamedID.java
@@ -1,0 +1,52 @@
+package me.hydos.rosella.util;
+
+import net.jpountz.xxhash.XXHashFactory;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Utility class to quickly identify and compare entities while retaining a human readable name.
+ *
+ * Creating instances is (relatively) slow but comparing existing ones is very fast so it is highly
+ * recommended to avoid creating new instances when not necessary. (Also reduces typing mistakes)
+ */
+public class NamedID implements Comparable<NamedID> {
+
+    public final String name;
+    public final long id;
+
+    public NamedID(@NotNull String name) {
+        assert(!name.isBlank());
+
+        this.name = name;
+        byte[] bytes = name.getBytes(StandardCharsets.UTF_8);
+        this.id = XXHashFactory.fastestJavaInstance().hash64().hash(bytes, 0, bytes.length, 0);
+    }
+
+    @Override
+    public int compareTo(@NotNull NamedID other) {
+        long diff = this.id - other.id;
+        if(diff == 0) {
+            return 0;
+        }
+        if(diff < 0) {
+            return -1;
+        } else {
+            return 1;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NamedID namedID = (NamedID) o;
+        return id == namedID.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) (id);
+    }
+}

--- a/src/main/java/me/hydos/rosella/util/VkUtils.java
+++ b/src/main/java/me/hydos/rosella/util/VkUtils.java
@@ -2,7 +2,7 @@ package me.hydos.rosella.util;
 
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import me.hydos.rosella.device.QueueFamilyIndices;
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.memory.BufferInfo;
 import me.hydos.rosella.memory.Memory;
 import me.hydos.rosella.render.renderer.Renderer;
@@ -65,7 +65,7 @@ public class VkUtils {
         }
     }
 
-    public static PointerBuffer allocateCommandBuffers(VulkanDevice device, long commandPool, int commandBuffersCount, int level) {
+    public static PointerBuffer allocateCommandBuffers(LegacyVulkanDevice device, long commandPool, int commandBuffersCount, int level) {
         PointerBuffer pCommandBuffers = stackGet().callocPointer(commandBuffersCount);
         try (MemoryStack stack = stackPush()) {
             VkCommandBufferAllocateInfo allocInfo = VkCommandBufferAllocateInfo.callocStack(stack)
@@ -79,7 +79,7 @@ public class VkUtils {
         return pCommandBuffers;
     }
 
-    public static PointerBuffer allocateCommandBuffers(VulkanDevice device, long commandPool, int commandBuffersCount) {
+    public static PointerBuffer allocateCommandBuffers(LegacyVulkanDevice device, long commandPool, int commandBuffersCount) {
         return allocateCommandBuffers(device, commandPool, commandBuffersCount, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
     }
 
@@ -104,7 +104,7 @@ public class VkUtils {
         return createRenderArea(0, 0, swapchain);
     }
 
-    public static long createImageView(VulkanDevice device, long image, int format, int aspectFlags) {
+    public static long createImageView(LegacyVulkanDevice device, long image, int format, int aspectFlags) {
         try (MemoryStack stack = stackPush()) {
             VkImageViewCreateInfo viewInfo = VkImageViewCreateInfo.callocStack(stack)
                     .sType(VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO)
@@ -126,7 +126,7 @@ public class VkUtils {
         }
     }
 
-    public static void createSwapchainImageViews(Swapchain swapchain, VulkanDevice device) {
+    public static void createSwapchainImageViews(Swapchain swapchain, LegacyVulkanDevice device) {
         swapchain.setSwapChainImageViews(new LongArrayList(swapchain.getSwapChainImages().size()));
 
         for (long swapChainImage : swapchain.getSwapChainImages()) {
@@ -141,7 +141,7 @@ public class VkUtils {
         }
     }
 
-    public static long createTextureImageView(VulkanDevice device, int imgFormat, long textureImage) {
+    public static long createTextureImageView(LegacyVulkanDevice device, int imgFormat, long textureImage) {
         return createImageView(device, textureImage, imgFormat, VK_IMAGE_ASPECT_COLOR_BIT);
     }
 
@@ -149,7 +149,7 @@ public class VkUtils {
         return findQueueFamilies(device.getPhysicalDevice(), surface);
     }
 
-    public static QueueFamilyIndices findQueueFamilies(VulkanDevice device, long surface) {
+    public static QueueFamilyIndices findQueueFamilies(LegacyVulkanDevice device, long surface) {
         return findQueueFamilies(device.physicalDevice, surface);
     }
 
@@ -179,7 +179,7 @@ public class VkUtils {
         }
     }
 
-    public static void createCommandPool(VulkanDevice device, Renderer renderer, long surface) {
+    public static void createCommandPool(LegacyVulkanDevice device, Renderer renderer, long surface) {
         try (MemoryStack stack = stackPush()) {
             QueueFamilyIndices queueFamilyIndices = findQueueFamilies(device, surface);
             VkCommandPoolCreateInfo poolInfo = VkCommandPoolCreateInfo.callocStack(stack)
@@ -200,13 +200,13 @@ public class VkUtils {
         return clearValues;
     }
 
-    public static VkCommandBuffer beginSingleTimeCommands(Renderer renderer, VulkanDevice device) {
+    public static VkCommandBuffer beginSingleTimeCommands(Renderer renderer, LegacyVulkanDevice device) {
         MemoryStack stack = stackGet();
         PointerBuffer pCommandBuffer = stack.mallocPointer(1);
         return renderer.beginCmdBuffer(pCommandBuffer, device);
     }
 
-    public static void endSingleTimeCommands(VkCommandBuffer commandBuffer, VulkanDevice device, Renderer renderer) {
+    public static void endSingleTimeCommands(VkCommandBuffer commandBuffer, LegacyVulkanDevice device, Renderer renderer) {
         try (MemoryStack stack = stackPush()) {
             vkEndCommandBuffer(commandBuffer);
             VkSubmitInfo.Buffer submitInfo = VkSubmitInfo.callocStack(1, stack)
@@ -218,7 +218,7 @@ public class VkUtils {
         }
     }
 
-    public static int findMemoryType(VulkanDevice device, int typeFilter, int properties) {
+    public static int findMemoryType(LegacyVulkanDevice device, int typeFilter, int properties) {
         VkPhysicalDeviceMemoryProperties memProperties = VkPhysicalDeviceMemoryProperties.mallocStack();
         vkGetPhysicalDeviceMemoryProperties(device.physicalDevice, memProperties);
         for (int i = 0; i < memProperties.memoryTypeCount(); i++) {
@@ -248,7 +248,7 @@ public class VkUtils {
         }
     }
 
-    public static TextureImage createTextureImage(Renderer renderer, Memory memory, VulkanDevice device, int width, int height, int imgFormat) {
+    public static TextureImage createTextureImage(Renderer renderer, Memory memory, LegacyVulkanDevice device, int width, int height, int imgFormat) {
         TextureImage image = createImage(
                 memory,
                 width,
@@ -273,7 +273,7 @@ public class VkUtils {
         return image;
     }
 
-    public static void transitionImageLayout(Renderer renderer, VulkanDevice device, DepthBuffer depthBuffer, long image, int format, int oldLayout, int newLayout) {
+    public static void transitionImageLayout(Renderer renderer, LegacyVulkanDevice device, DepthBuffer depthBuffer, long image, int format, int oldLayout, int newLayout) {
         try (MemoryStack stack = stackPush()) {
             VkImageMemoryBarrier.Buffer barrier = VkImageMemoryBarrier.callocStack(1, stack)
                     .sType(VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER)
@@ -338,7 +338,7 @@ public class VkUtils {
         }
     }
 
-    public static void copyToTexture(Renderer renderer, VulkanDevice device, Memory memory, UploadableImage image, ImageRegion srcRegion, ImageRegion dstRegion, Texture texture) {
+    public static void copyToTexture(Renderer renderer, LegacyVulkanDevice device, Memory memory, UploadableImage image, ImageRegion srcRegion, ImageRegion dstRegion, Texture texture) {
         try (MemoryStack stack = stackPush()) {
             LongBuffer pBuffer = stack.mallocLong(1);
             BufferInfo stagingBuf = memory.createStagingBuf(
@@ -371,7 +371,7 @@ public class VkUtils {
         }
     }
 
-    public static void copyBufferToImage(Renderer renderer, VulkanDevice device, long buffer, long image, int srcImageWidth, int srcImageHeight, int srcXOffset, int srcYOffset, int srcPixelSize, int dstRegionWidth, int dstRegionHeight, int dstXOffset, int dstYOffset) {
+    public static void copyBufferToImage(Renderer renderer, LegacyVulkanDevice device, long buffer, long image, int srcImageWidth, int srcImageHeight, int srcXOffset, int srcYOffset, int srcPixelSize, int dstRegionWidth, int dstRegionHeight, int dstXOffset, int dstYOffset) {
         // TODO: add support for mip levels
         // TODO OPT: use linear layout until first prepare, then keep it at optimal. copying to linear is faster but reading is slower.
         try (MemoryStack stack = stackPush()) {

--- a/src/main/java/me/hydos/rosella/vkobjects/LegacyVulkanInstance.java
+++ b/src/main/java/me/hydos/rosella/vkobjects/LegacyVulkanInstance.java
@@ -19,13 +19,13 @@ import static org.lwjgl.vulkan.VK12.VK_API_VERSION_1_2;
 /**
  * {@link me.hydos.rosella.Rosella} representation of a {@link VkInstance}. Contains a couple of useful things here and there and does most of the work for you.
  */
-public class VulkanInstance {
+public class LegacyVulkanInstance {
 
     public final DebugLogger debugLogger;
     public final VkInstance rawInstance;
     public final OptionalLong messenger;
 
-    public VulkanInstance(List<String> requestedValidationLayers, List<String> requestedExtensions, String applicationName, DebugLogger debugLogger) {
+    public LegacyVulkanInstance(List<String> requestedValidationLayers, List<String> requestedExtensions, String applicationName, DebugLogger debugLogger) {
         this.debugLogger = debugLogger;
 
         boolean validationLayers = !requestedValidationLayers.isEmpty();

--- a/src/main/java/me/hydos/rosella/vkobjects/LegacyVulkanInstance.java
+++ b/src/main/java/me/hydos/rosella/vkobjects/LegacyVulkanInstance.java
@@ -1,5 +1,9 @@
 package me.hydos.rosella.vkobjects;
 
+import me.hydos.rosella.debug.LegacyDebugCallback;
+import me.hydos.rosella.init.InitializationRegistry;
+import me.hydos.rosella.init.InstanceBuilder;
+import me.hydos.rosella.init.VulkanInstance;
 import me.hydos.rosella.logging.DebugLogger;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
@@ -19,13 +23,30 @@ import static org.lwjgl.vulkan.VK12.VK_API_VERSION_1_2;
 /**
  * {@link me.hydos.rosella.Rosella} representation of a {@link VkInstance}. Contains a couple of useful things here and there and does most of the work for you.
  */
+@Deprecated
 public class LegacyVulkanInstance {
+
+    public final VulkanInstance newInstance;
 
     public final DebugLogger debugLogger;
     public final VkInstance rawInstance;
     public final OptionalLong messenger;
 
+    public LegacyVulkanInstance(InitializationRegistry registry, String applicationName, int applicationVersion, DebugLogger logger) {
+        this.debugLogger = logger;
+
+        registry.addDebugCallback(new LegacyDebugCallback(this.debugLogger));
+
+        InstanceBuilder builder = new InstanceBuilder(registry);
+        this.newInstance = builder.build(applicationName, applicationVersion);
+
+        this.rawInstance = newInstance.getInstance();
+        this.messenger = OptionalLong.empty();
+    }
+
     public LegacyVulkanInstance(List<String> requestedValidationLayers, List<String> requestedExtensions, String applicationName, DebugLogger debugLogger) {
+        this.newInstance = null;
+
         this.debugLogger = debugLogger;
 
         boolean validationLayers = !requestedValidationLayers.isEmpty();

--- a/src/main/java/me/hydos/rosella/vkobjects/VkCommon.java
+++ b/src/main/java/me/hydos/rosella/vkobjects/VkCommon.java
@@ -29,7 +29,7 @@ public class VkCommon {
     /**
      * The instance of vulkan and the debug logger.
      */
-    public VulkanInstance vkInstance;
+    public LegacyVulkanInstance vkInstance;
 
     /**
      * The surface of what we are displaying to. In general it will be a GLFW window surface.

--- a/src/main/java/me/hydos/rosella/vkobjects/VkCommon.java
+++ b/src/main/java/me/hydos/rosella/vkobjects/VkCommon.java
@@ -1,6 +1,6 @@
 package me.hydos.rosella.vkobjects;
 
-import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.device.LegacyVulkanDevice;
 import me.hydos.rosella.device.VulkanQueues;
 import me.hydos.rosella.display.Display;
 import me.hydos.rosella.memory.Memory;
@@ -39,7 +39,7 @@ public class VkCommon {
     /**
      * The logical and physical device. used in most Vulkan calls.
      */
-    public VulkanDevice device;
+    public LegacyVulkanDevice device;
 
     /**
      * The Presentation and Graphics queue.

--- a/src/main/kotlin/me/hydos/rosella/render/shader/RawShaderProgram.kt
+++ b/src/main/kotlin/me/hydos/rosella/render/shader/RawShaderProgram.kt
@@ -2,7 +2,7 @@ package me.hydos.rosella.render.shader
 
 import it.unimi.dsi.fastutil.Hash.VERY_FAST_LOAD_FACTOR
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet
-import me.hydos.rosella.device.VulkanDevice
+import me.hydos.rosella.device.LegacyVulkanDevice
 import me.hydos.rosella.memory.Memory
 import me.hydos.rosella.render.descriptorsets.DescriptorSets
 import me.hydos.rosella.render.renderer.Renderer
@@ -18,12 +18,12 @@ import org.lwjgl.vulkan.*
 import org.lwjgl.vulkan.VK10.*
 
 open class RawShaderProgram(
-    var vertexShader: Resource?,
-    var fragmentShader: Resource?,
-    val device: VulkanDevice,
-    val memory: Memory,
-    var maxObjCount: Int,
-    private vararg var poolObjects: PoolObjectInfo
+        var vertexShader: Resource?,
+        var fragmentShader: Resource?,
+        val device: LegacyVulkanDevice,
+        val memory: Memory,
+        var maxObjCount: Int,
+        private vararg var poolObjects: PoolObjectInfo
 ) {
     var descriptorPool: Long = 0
     var descriptorSetLayout: Long = 0

--- a/src/main/kotlin/me/hydos/rosella/render/shader/ShaderProgram.kt
+++ b/src/main/kotlin/me/hydos/rosella/render/shader/ShaderProgram.kt
@@ -1,7 +1,7 @@
 package me.hydos.rosella.render.shader
 
 import me.hydos.rosella.Rosella
-import me.hydos.rosella.device.VulkanDevice
+import me.hydos.rosella.device.LegacyVulkanDevice
 import me.hydos.rosella.render.util.compileShaderFile
 import me.hydos.rosella.util.VkUtils.ok
 import me.hydos.rosella.ubo.DescriptorManager
@@ -30,7 +30,7 @@ class ShaderProgram(val raw: RawShaderProgram, val rosella: Rosella, maxObjects:
     /**
      * Create a Vulkan shader module. used during pipeline creation.
      */
-    private fun createShader(spirvCode: ByteBuffer, device: VulkanDevice): Long {
+    private fun createShader(spirvCode: ByteBuffer, device: LegacyVulkanDevice): Long {
         MemoryStack.stackPush().use { stack ->
             val createInfo = VkShaderModuleCreateInfo.callocStack(stack)
                 .sType(VK10.VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)

--- a/src/main/kotlin/me/hydos/rosella/render/shader/ubo/RenderObjectUbo.kt
+++ b/src/main/kotlin/me/hydos/rosella/render/shader/ubo/RenderObjectUbo.kt
@@ -1,6 +1,6 @@
 package me.hydos.rosella.render.shader.ubo
 
-import me.hydos.rosella.device.VulkanDevice
+import me.hydos.rosella.device.LegacyVulkanDevice
 import me.hydos.rosella.memory.BufferInfo
 import me.hydos.rosella.memory.Memory
 import me.hydos.rosella.render.descriptorsets.DescriptorSets
@@ -14,10 +14,10 @@ import org.lwjgl.util.vma.Vma
 import org.lwjgl.vulkan.VK10
 
 open class RenderObjectUbo(
-    val device: VulkanDevice,
-    val memory: Memory,
-    private val renderObject: RenderObject,
-    shaderProgram: ShaderProgram
+        val device: LegacyVulkanDevice,
+        val memory: Memory,
+        private val renderObject: RenderObject,
+        shaderProgram: ShaderProgram
 ) : Ubo() {
 
     private var uboFrames: MutableList<BufferInfo> = ArrayList()

--- a/src/main/kotlin/me/hydos/rosella/render/shader/ubo/Ubo.kt
+++ b/src/main/kotlin/me/hydos/rosella/render/shader/ubo/Ubo.kt
@@ -1,6 +1,6 @@
 package me.hydos.rosella.render.shader.ubo
 
-import me.hydos.rosella.device.VulkanDevice
+import me.hydos.rosella.device.LegacyVulkanDevice
 import me.hydos.rosella.memory.BufferInfo
 import me.hydos.rosella.memory.Memory
 import me.hydos.rosella.memory.MemoryCloseable
@@ -45,7 +45,7 @@ abstract class Ubo : MemoryCloseable {
     /**
      * Called when the program is closing and free's memory
      */
-    override fun free(device: VulkanDevice?, memory: Memory?) {
+    override fun free(device: LegacyVulkanDevice?, memory: Memory?) {
         free()
     }
 

--- a/src/main/kotlin/me/hydos/rosella/render/swapchain/DepthBuffer.kt
+++ b/src/main/kotlin/me/hydos/rosella/render/swapchain/DepthBuffer.kt
@@ -1,6 +1,6 @@
 package me.hydos.rosella.render.swapchain
 
-import me.hydos.rosella.device.VulkanDevice
+import me.hydos.rosella.device.LegacyVulkanDevice
 import me.hydos.rosella.memory.Memory
 import me.hydos.rosella.memory.MemoryCloseable
 import me.hydos.rosella.render.renderer.Renderer
@@ -19,7 +19,7 @@ class DepthBuffer: MemoryCloseable {
 
     lateinit var depthImage: TextureImage
 
-    fun createDepthResources(device: VulkanDevice, memory: Memory, swapchain: Swapchain, renderer: Renderer) {
+    fun createDepthResources(device: LegacyVulkanDevice, memory: Memory, swapchain: Swapchain, renderer: Renderer) {
         val depthFormat = findDepthFormat(device)
         depthImage = VkUtils.createImage(
             memory,
@@ -45,7 +45,7 @@ class DepthBuffer: MemoryCloseable {
         )
     }
 
-    fun findDepthFormat(device: VulkanDevice): Int {
+    fun findDepthFormat(device: LegacyVulkanDevice): Int {
         return findSupportedFormat(
             MemoryStack.stackGet()
                 .ints(VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT),
@@ -63,7 +63,7 @@ class DepthBuffer: MemoryCloseable {
         formatCandidates: IntBuffer,
         tiling: Int,
         features: Int,
-        device: VulkanDevice
+        device: LegacyVulkanDevice
     ): Int {
         MemoryStack.stackPush().use { stack ->
             val props = VkFormatProperties.callocStack(stack)
@@ -80,7 +80,7 @@ class DepthBuffer: MemoryCloseable {
         error("Failed to find supported format")
     }
 
-    override fun free(device: VulkanDevice, memory: Memory) {
+    override fun free(device: LegacyVulkanDevice, memory: Memory) {
         depthImage.free(device, memory)
     }
 }

--- a/src/main/kotlin/me/hydos/rosella/render/texture/TextureSampler.kt
+++ b/src/main/kotlin/me/hydos/rosella/render/texture/TextureSampler.kt
@@ -1,6 +1,6 @@
 package me.hydos.rosella.render.texture
 
-import me.hydos.rosella.device.VulkanDevice
+import me.hydos.rosella.device.LegacyVulkanDevice
 import org.lwjgl.system.MemoryStack
 import org.lwjgl.vulkan.VK10
 import org.lwjgl.vulkan.VkSamplerCreateInfo
@@ -8,7 +8,7 @@ import org.lwjgl.vulkan.VkSamplerCreateInfo
 /**
  * The creation info for creating a Texture Sampler
  */
-class TextureSampler(private val createInfo: SamplerCreateInfo, device: VulkanDevice) {
+class TextureSampler(private val createInfo: SamplerCreateInfo, device: LegacyVulkanDevice) {
     var pointer = 0L
 
     init {

--- a/src/test/java/me/hydos/rosella/annotations/RequiresVulkan.java
+++ b/src/test/java/me/hydos/rosella/annotations/RequiresVulkan.java
@@ -1,0 +1,14 @@
+package me.hydos.rosella.annotations;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * These are tests that require the vulkan runtime to run.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("requires_vulkan")
+public @interface RequiresVulkan {
+}

--- a/src/test/java/me/hydos/rosella/example/PortalJava.java
+++ b/src/test/java/me/hydos/rosella/example/PortalJava.java
@@ -2,6 +2,7 @@ package me.hydos.rosella.example;
 
 import me.hydos.rosella.Rosella;
 import me.hydos.rosella.display.GlfwWindow;
+import me.hydos.rosella.init.InitializationRegistry;
 import me.hydos.rosella.render.Topology;
 import me.hydos.rosella.render.material.Material;
 import me.hydos.rosella.render.material.state.StateInfo;
@@ -22,7 +23,7 @@ import org.lwjgl.vulkan.VK10;
 public class PortalJava {
 
     public static final GlfwWindow window = new GlfwWindow(1280, 720, "Portal 3: Java Edition", true);
-    public static final Rosella rosella = new Rosella(window, "Portal 3", true);
+    public static final Rosella rosella = new Rosella(new InitializationRegistry(), window,"Portal 3", VK10.VK_MAKE_VERSION(1, 0, 0));
 
     public static final Matrix4f viewMatrix = new Matrix4f().lookAt(2.0f, -40.0f, 2.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f);
     public static final Matrix4f projectionMatrix = new Matrix4f().perspective(

--- a/src/test/java/me/hydos/rosella/example/PortalJava.java
+++ b/src/test/java/me/hydos/rosella/example/PortalJava.java
@@ -56,7 +56,7 @@ public class PortalJava {
     );
 
     public static void main(String[] args) {
-        System.loadLibrary("renderdoc");
+        //System.loadLibrary("renderdoc");
         loadShaders();
         loadMaterials();
         setupMainMenuScene();

--- a/src/test/java/me/hydos/rosella/example/PortalJava.java
+++ b/src/test/java/me/hydos/rosella/example/PortalJava.java
@@ -29,7 +29,7 @@ public class PortalJava {
     public static final int TOP = 720;
 
     static {
-        System.loadLibrary("renderdoc");
+        //System.loadLibrary("renderdoc");
         window = new GlfwWindow(WIDTH, TOP, "Portal 3: Java Edition", true);
         rosella = new Rosella(new InitializationRegistry(), window, "Portal 3", VK10.VK_MAKE_VERSION(1, 0, 0));
     }

--- a/src/test/java/me/hydos/rosella/example/PortalJava.java
+++ b/src/test/java/me/hydos/rosella/example/PortalJava.java
@@ -29,7 +29,7 @@ public class PortalJava {
     public static final int TOP = 720;
 
     static {
-        //System.loadLibrary("renderdoc");
+        System.loadLibrary("renderdoc");
         window = new GlfwWindow(WIDTH, TOP, "Portal 3: Java Edition", true);
         rosella = new Rosella(new InitializationRegistry(), window, "Portal 3", VK10.VK_MAKE_VERSION(1, 0, 0));
     }

--- a/src/test/java/me/hydos/rosella/init/TestDeviceBuilder.java
+++ b/src/test/java/me/hydos/rosella/init/TestDeviceBuilder.java
@@ -2,6 +2,8 @@ package me.hydos.rosella.init;
 
 import me.hydos.rosella.annotations.RequiresVulkan;
 import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.init.features.ApplicationFeature;
+import me.hydos.rosella.init.features.SimpleApplicationFeature;
 import me.hydos.rosella.test_utils.VulkanTestInstance;
 import org.junit.jupiter.api.Test;
 
@@ -32,11 +34,11 @@ public class TestDeviceBuilder {
     @RequiresVulkan
     void testBasicFeatures() {
         ArrayList<ApplicationFeature> features = new ArrayList<>();
-        features.add(new ApplicationFeature("t:test1"));
-        features.add(new ApplicationFeature("t:test2"));
+        features.add(new SimpleApplicationFeature("t:test1", null));
+        features.add(new SimpleApplicationFeature("t:test2", null));
 
         ArrayList<ApplicationFeature> failFeatures = new ArrayList<>();
-        failFeatures.add(new ApplicationFeature("t:test3", Set.of("t:fail")));
+        failFeatures.add(new SimpleApplicationFeature("t:test3", Set.of("t:fail")));
 
         InitializationRegistry registry1 = new InitializationRegistry();
         features.forEach(registry1::registerApplicationFeature);
@@ -63,8 +65,8 @@ public class TestDeviceBuilder {
     @RequiresVulkan
     void testRequiredFeatures() {
         ArrayList<ApplicationFeature> features = new ArrayList<>();
-        features.add(new ApplicationFeature("t:test1"));
-        features.add(new ApplicationFeature("t:test2"));
+        features.add(new SimpleApplicationFeature("t:test1", null));
+        features.add(new SimpleApplicationFeature("t:test2", null));
 
         InitializationRegistry registry1 = new InitializationRegistry();
         features.forEach(registry1::registerApplicationFeature);
@@ -87,8 +89,8 @@ public class TestDeviceBuilder {
     @RequiresVulkan
     void testRequiredFeaturesFail() {
         ArrayList<ApplicationFeature> features = new ArrayList<>();
-        features.add(new ApplicationFeature("t:test1"));
-        features.add(new ApplicationFeature("t:test2", Set.of("t:fail")));
+        features.add(new SimpleApplicationFeature("t:test1", null));
+        features.add(new SimpleApplicationFeature("t:test2", Set.of("t:fail")));
 
         InitializationRegistry registry1 = new InitializationRegistry();
         features.forEach(registry1::registerApplicationFeature);
@@ -106,19 +108,19 @@ public class TestDeviceBuilder {
     @RequiresVulkan
     void testDependencyOrdering() {
         ArrayList<ApplicationFeature> features = new ArrayList<>();
-        features.add(new ApplicationFeature("t:test9"));
-        features.add(new ApplicationFeature("t:test2", Set.of("t:test9")));
-        features.add(new ApplicationFeature("t:test3", Set.of("t:test2")));
-        features.add(new ApplicationFeature("t:test4", Set.of("t:test9", "t:test2")));
-        features.add(new ApplicationFeature("t:test5", Set.of("t:test2")));
-        features.add(new ApplicationFeature("t:test6", Set.of("t:test4")));
-        features.add(new ApplicationFeature("t:test7", Set.of("t:test4")));
+        features.add(new SimpleApplicationFeature("t:test9", null));
+        features.add(new SimpleApplicationFeature("t:test2", Set.of("t:test9")));
+        features.add(new SimpleApplicationFeature("t:test3", Set.of("t:test2")));
+        features.add(new SimpleApplicationFeature("t:test4", Set.of("t:test9", "t:test2")));
+        features.add(new SimpleApplicationFeature("t:test5", Set.of("t:test2")));
+        features.add(new SimpleApplicationFeature("t:test6", Set.of("t:test4")));
+        features.add(new SimpleApplicationFeature("t:test7", Set.of("t:test4")));
 
         ArrayList<ApplicationFeature> failFeatures = new ArrayList<>();
-        failFeatures.add(new ApplicationFeature("t:test11", Set.of("t:fail")));
-        failFeatures.add(new ApplicationFeature("t:test12", Set.of("t:test11")));
-        failFeatures.add(new ApplicationFeature("t:test13", Set.of("t:test12", "t:test2")));
-        failFeatures.add(new ApplicationFeature("t:test14", Set.of("t:test13")));
+        failFeatures.add(new SimpleApplicationFeature("t:test11", Set.of("t:fail")));
+        failFeatures.add(new SimpleApplicationFeature("t:test12", Set.of("t:test11")));
+        failFeatures.add(new SimpleApplicationFeature("t:test13", Set.of("t:test12", "t:test2")));
+        failFeatures.add(new SimpleApplicationFeature("t:test14", Set.of("t:test13")));
 
         Random rand = new Random(293840972);
         Collections.shuffle(features, rand);

--- a/src/test/java/me/hydos/rosella/init/TestDeviceBuilder.java
+++ b/src/test/java/me/hydos/rosella/init/TestDeviceBuilder.java
@@ -1,4 +1,25 @@
 package me.hydos.rosella.init;
 
+import me.hydos.rosella.annotations.RequiresVulkan;
+import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.test_utils.VulkanTestInstance;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 public class TestDeviceBuilder {
+
+    @Test
+    @RequiresVulkan
+    void testMinimalBuild() {
+        InitializationRegistry registry = new InitializationRegistry();
+        try (VulkanTestInstance instance = new VulkanTestInstance(registry)) {
+
+            assertDoesNotThrow(() -> {
+                DeviceBuilder builder = new DeviceBuilder(instance.instance, registry);
+                VulkanDevice device = builder.build();
+                device.destroy();
+            });
+        }
+    }
 }

--- a/src/test/java/me/hydos/rosella/init/TestDeviceBuilder.java
+++ b/src/test/java/me/hydos/rosella/init/TestDeviceBuilder.java
@@ -1,0 +1,4 @@
+package me.hydos.rosella.init;
+
+public class TestDeviceBuilder {
+}

--- a/src/test/java/me/hydos/rosella/init/TestDeviceBuilder.java
+++ b/src/test/java/me/hydos/rosella/init/TestDeviceBuilder.java
@@ -5,6 +5,7 @@ import me.hydos.rosella.device.VulkanDevice;
 import me.hydos.rosella.init.features.ApplicationFeature;
 import me.hydos.rosella.init.features.SimpleApplicationFeature;
 import me.hydos.rosella.test_utils.VulkanTestInstance;
+import me.hydos.rosella.util.NamedID;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -34,11 +35,11 @@ public class TestDeviceBuilder {
     @RequiresVulkan
     void testBasicFeatures() {
         ArrayList<ApplicationFeature> features = new ArrayList<>();
-        features.add(new SimpleApplicationFeature("t:test1", null));
-        features.add(new SimpleApplicationFeature("t:test2", null));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test1"), null));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test2"), null));
 
         ArrayList<ApplicationFeature> failFeatures = new ArrayList<>();
-        failFeatures.add(new SimpleApplicationFeature("t:test3", Set.of("t:fail")));
+        failFeatures.add(new SimpleApplicationFeature(new NamedID("t:test3"), Set.of(new NamedID("t:fail"))));
 
         InitializationRegistry registry1 = new InitializationRegistry();
         features.forEach(registry1::registerApplicationFeature);
@@ -65,12 +66,12 @@ public class TestDeviceBuilder {
     @RequiresVulkan
     void testRequiredFeatures() {
         ArrayList<ApplicationFeature> features = new ArrayList<>();
-        features.add(new SimpleApplicationFeature("t:test1", null));
-        features.add(new SimpleApplicationFeature("t:test2", null));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test1"), null));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test2"), null));
 
         InitializationRegistry registry1 = new InitializationRegistry();
         features.forEach(registry1::registerApplicationFeature);
-        registry1.addRequiredApplicationFeature("t:test2");
+        registry1.addRequiredApplicationFeature(new NamedID("t:test2"));
         try(VulkanTestInstance instance = new VulkanTestInstance(registry1)) {
             assertDoesNotThrow(() -> {
                 DeviceBuilder builder = new DeviceBuilder(instance.instance, registry1);
@@ -89,12 +90,12 @@ public class TestDeviceBuilder {
     @RequiresVulkan
     void testRequiredFeaturesFail() {
         ArrayList<ApplicationFeature> features = new ArrayList<>();
-        features.add(new SimpleApplicationFeature("t:test1", null));
-        features.add(new SimpleApplicationFeature("t:test2", Set.of("t:fail")));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test1"), null));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test2"), Set.of(new NamedID("t:fail"))));
 
         InitializationRegistry registry1 = new InitializationRegistry();
         features.forEach(registry1::registerApplicationFeature);
-        registry1.addRequiredApplicationFeature("t:test2");
+        registry1.addRequiredApplicationFeature(new NamedID("t:test2"));
         try(VulkanTestInstance instance = new VulkanTestInstance(registry1)) {
             assertThrows(RuntimeException.class, () -> {
                 DeviceBuilder builder = new DeviceBuilder(instance.instance, registry1);
@@ -108,19 +109,19 @@ public class TestDeviceBuilder {
     @RequiresVulkan
     void testDependencyOrdering() {
         ArrayList<ApplicationFeature> features = new ArrayList<>();
-        features.add(new SimpleApplicationFeature("t:test9", null));
-        features.add(new SimpleApplicationFeature("t:test2", Set.of("t:test9")));
-        features.add(new SimpleApplicationFeature("t:test3", Set.of("t:test2")));
-        features.add(new SimpleApplicationFeature("t:test4", Set.of("t:test9", "t:test2")));
-        features.add(new SimpleApplicationFeature("t:test5", Set.of("t:test2")));
-        features.add(new SimpleApplicationFeature("t:test6", Set.of("t:test4")));
-        features.add(new SimpleApplicationFeature("t:test7", Set.of("t:test4")));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test9"), null));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test2"), Set.of(new NamedID("t:test9"))));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test3"), Set.of(new NamedID("t:test2"))));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test4"), Set.of(new NamedID("t:test9"), new NamedID("t:test2"))));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test5"), Set.of(new NamedID("t:test2"))));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test6"), Set.of(new NamedID("t:test4"))));
+        features.add(new SimpleApplicationFeature(new NamedID("t:test7"), Set.of(new NamedID("t:test4"))));
 
         ArrayList<ApplicationFeature> failFeatures = new ArrayList<>();
-        failFeatures.add(new SimpleApplicationFeature("t:test11", Set.of("t:fail")));
-        failFeatures.add(new SimpleApplicationFeature("t:test12", Set.of("t:test11")));
-        failFeatures.add(new SimpleApplicationFeature("t:test13", Set.of("t:test12", "t:test2")));
-        failFeatures.add(new SimpleApplicationFeature("t:test14", Set.of("t:test13")));
+        failFeatures.add(new SimpleApplicationFeature(new NamedID("t:test11"), Set.of(new NamedID("t:fail"))));
+        failFeatures.add(new SimpleApplicationFeature(new NamedID("t:test12"), Set.of(new NamedID("t:test11"))));
+        failFeatures.add(new SimpleApplicationFeature(new NamedID("t:test13"), Set.of(new NamedID("t:test12"), new NamedID("t:test2"))));
+        failFeatures.add(new SimpleApplicationFeature(new NamedID("t:test14"), Set.of(new NamedID("t:test13"))));
 
         Random rand = new Random(293840972);
         Collections.shuffle(features, rand);

--- a/src/test/java/me/hydos/rosella/init/TestDeviceBuilder.java
+++ b/src/test/java/me/hydos/rosella/init/TestDeviceBuilder.java
@@ -5,6 +5,11 @@ import me.hydos.rosella.device.VulkanDevice;
 import me.hydos.rosella.test_utils.VulkanTestInstance;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Random;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestDeviceBuilder {
@@ -18,6 +23,124 @@ public class TestDeviceBuilder {
             assertDoesNotThrow(() -> {
                 DeviceBuilder builder = new DeviceBuilder(instance.instance, registry);
                 VulkanDevice device = builder.build();
+                device.destroy();
+            });
+        }
+    }
+
+    @Test
+    @RequiresVulkan
+    void testBasicFeatures() {
+        ArrayList<ApplicationFeature> features = new ArrayList<>();
+        features.add(new ApplicationFeature("t:test1"));
+        features.add(new ApplicationFeature("t:test2"));
+
+        ArrayList<ApplicationFeature> failFeatures = new ArrayList<>();
+        failFeatures.add(new ApplicationFeature("t:test3", Set.of("t:fail")));
+
+        InitializationRegistry registry1 = new InitializationRegistry();
+        features.forEach(registry1::registerApplicationFeature);
+        failFeatures.forEach(registry1::registerApplicationFeature);
+        try(VulkanTestInstance instance = new VulkanTestInstance(registry1)) {
+            assertDoesNotThrow(() -> {
+                DeviceBuilder builder = new DeviceBuilder(instance.instance, registry1);
+                VulkanDevice device = builder.build();
+
+                features.forEach((feature) ->
+                    assertTrue(device.isFeatureEnabled(feature.name))
+                );
+
+                failFeatures.forEach((feature) ->
+                    assertFalse(device.isFeatureEnabled(feature.name))
+                );
+
+                device.destroy();
+            });
+        }
+    }
+
+    @Test
+    @RequiresVulkan
+    void testRequiredFeatures() {
+        ArrayList<ApplicationFeature> features = new ArrayList<>();
+        features.add(new ApplicationFeature("t:test1"));
+        features.add(new ApplicationFeature("t:test2"));
+
+        InitializationRegistry registry1 = new InitializationRegistry();
+        features.forEach(registry1::registerApplicationFeature);
+        registry1.addRequiredApplicationFeature("t:test2");
+        try(VulkanTestInstance instance = new VulkanTestInstance(registry1)) {
+            assertDoesNotThrow(() -> {
+                DeviceBuilder builder = new DeviceBuilder(instance.instance, registry1);
+                VulkanDevice device = builder.build();
+
+                features.forEach((feature) ->
+                    assertTrue(device.isFeatureEnabled(feature.name))
+                );
+
+                device.destroy();
+            });
+        }
+    }
+
+    @Test
+    @RequiresVulkan
+    void testRequiredFeaturesFail() {
+        ArrayList<ApplicationFeature> features = new ArrayList<>();
+        features.add(new ApplicationFeature("t:test1"));
+        features.add(new ApplicationFeature("t:test2", Set.of("t:fail")));
+
+        InitializationRegistry registry1 = new InitializationRegistry();
+        features.forEach(registry1::registerApplicationFeature);
+        registry1.addRequiredApplicationFeature("t:test2");
+        try(VulkanTestInstance instance = new VulkanTestInstance(registry1)) {
+            assertThrows(RuntimeException.class, () -> {
+                DeviceBuilder builder = new DeviceBuilder(instance.instance, registry1);
+                VulkanDevice device = builder.build();
+                device.destroy();
+            });
+        }
+    }
+
+    @Test
+    @RequiresVulkan
+    void testDependencyOrdering() {
+        ArrayList<ApplicationFeature> features = new ArrayList<>();
+        features.add(new ApplicationFeature("t:test9"));
+        features.add(new ApplicationFeature("t:test2", Set.of("t:test9")));
+        features.add(new ApplicationFeature("t:test3", Set.of("t:test2")));
+        features.add(new ApplicationFeature("t:test4", Set.of("t:test9", "t:test2")));
+        features.add(new ApplicationFeature("t:test5", Set.of("t:test2")));
+        features.add(new ApplicationFeature("t:test6", Set.of("t:test4")));
+        features.add(new ApplicationFeature("t:test7", Set.of("t:test4")));
+
+        ArrayList<ApplicationFeature> failFeatures = new ArrayList<>();
+        failFeatures.add(new ApplicationFeature("t:test11", Set.of("t:fail")));
+        failFeatures.add(new ApplicationFeature("t:test12", Set.of("t:test11")));
+        failFeatures.add(new ApplicationFeature("t:test13", Set.of("t:test12", "t:test2")));
+        failFeatures.add(new ApplicationFeature("t:test14", Set.of("t:test13")));
+
+        Random rand = new Random(293840972);
+        Collections.shuffle(features, rand);
+        Collections.shuffle(failFeatures, rand);
+
+        InitializationRegistry registry = new InitializationRegistry();
+        features.forEach(registry::registerApplicationFeature);
+        failFeatures.forEach(registry::registerApplicationFeature);
+        try(VulkanTestInstance instance = new VulkanTestInstance(registry)) {
+
+            assertDoesNotThrow(() -> {
+                DeviceBuilder builder = new DeviceBuilder(instance.instance, registry);
+                VulkanDevice device = builder.build();
+
+                features.forEach((feature) ->
+                    assertTrue(device.isFeatureEnabled(feature.name))
+                );
+
+                failFeatures.forEach((feature) ->
+                    assertFalse(device.isFeatureEnabled(feature.name))
+                );
+
                 device.destroy();
             });
         }

--- a/src/test/java/me/hydos/rosella/init/TestInitializationRegistry.java
+++ b/src/test/java/me/hydos/rosella/init/TestInitializationRegistry.java
@@ -1,5 +1,7 @@
 package me.hydos.rosella.init;
 
+import me.hydos.rosella.init.features.ApplicationFeature;
+import me.hydos.rosella.init.features.SimpleApplicationFeature;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -11,7 +13,7 @@ public class TestInitializationRegistry {
     void testApplicationFeatureSortingIndividual() {
         List<String> names = List.of("testing:test1", "testing:test2", "testing:test3", "testing:test4");
         List<ApplicationFeature> features = new ArrayList<>();
-        names.forEach(name -> features.add(new ApplicationFeature(name)));
+        names.forEach(name -> features.add(new SimpleApplicationFeature(name, null)));
 
         InitializationRegistry registry = new InitializationRegistry();
         features.forEach(registry::registerApplicationFeature);
@@ -23,10 +25,10 @@ public class TestInitializationRegistry {
     @Test
     void testApplicationFeatureSortingSingeGroup() {
         List<ApplicationFeature> features = new ArrayList<>();
-        features.add(new ApplicationFeature("testing:test1", List.of("testing:test2")));
-        features.add(new ApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
-        features.add(new ApplicationFeature("testing:test3"));
-        features.add(new ApplicationFeature("testing:test4"));
+        features.add(new SimpleApplicationFeature("testing:test1", List.of("testing:test2")));
+        features.add(new SimpleApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
+        features.add(new SimpleApplicationFeature("testing:test3", null));
+        features.add(new SimpleApplicationFeature("testing:test4", null));
 
         Random rand = new Random(479821392);
         Collections.shuffle(features, rand);
@@ -46,21 +48,21 @@ public class TestInitializationRegistry {
     @Test
     void testApplicationFeatureSortingMultiGroup() {
         List<ApplicationFeature> features = new ArrayList<>();
-        features.add(new ApplicationFeature("testing:test1", List.of("testing:test2")));
-        features.add(new ApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
-        features.add(new ApplicationFeature("testing:test3"));
-        features.add(new ApplicationFeature("testing:test4"));
+        features.add(new SimpleApplicationFeature("testing:test1", List.of("testing:test2")));
+        features.add(new SimpleApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
+        features.add(new SimpleApplicationFeature("testing:test3", null));
+        features.add(new SimpleApplicationFeature("testing:test4", null));
 
-        features.add(new ApplicationFeature("testing:test6", List.of("testing:test7")));
-        features.add(new ApplicationFeature("testing:test5"));
-        features.add(new ApplicationFeature("testing:test7", List.of("testing:test5")));
+        features.add(new SimpleApplicationFeature("testing:test6", List.of("testing:test7")));
+        features.add(new SimpleApplicationFeature("testing:test5", null));
+        features.add(new SimpleApplicationFeature("testing:test7", List.of("testing:test5")));
 
-        features.add(new ApplicationFeature("testing:test9"));
+        features.add(new SimpleApplicationFeature("testing:test9", null));
 
-        features.add(new ApplicationFeature("testing:test10"));
-        features.add(new ApplicationFeature("testing:test11", List.of("testing:test10")));
-        features.add(new ApplicationFeature("testing:test12", List.of("testing:test10")));
-        features.add(new ApplicationFeature("testing:test13", List.of("testing:test11", "testing:test12")));
+        features.add(new SimpleApplicationFeature("testing:test10", null));
+        features.add(new SimpleApplicationFeature("testing:test11", List.of("testing:test10")));
+        features.add(new SimpleApplicationFeature("testing:test12", List.of("testing:test10")));
+        features.add(new SimpleApplicationFeature("testing:test13", List.of("testing:test11", "testing:test12")));
 
         Random rand = new Random(58234902);
         Collections.shuffle(features, rand);
@@ -80,10 +82,10 @@ public class TestInitializationRegistry {
     @Test
     void testApplicationFeatureSortingCycle() {
         List<ApplicationFeature> features = new ArrayList<>();
-        features.add(new ApplicationFeature("testing:test1", List.of("testing:test2")));
-        features.add(new ApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
-        features.add(new ApplicationFeature("testing:test3"));
-        features.add(new ApplicationFeature("testing:test4", List.of("testing:test1")));
+        features.add(new SimpleApplicationFeature("testing:test1", List.of("testing:test2")));
+        features.add(new SimpleApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
+        features.add(new SimpleApplicationFeature("testing:test3", null));
+        features.add(new SimpleApplicationFeature("testing:test4", List.of("testing:test1")));
 
         Random rand = new Random(479821392);
         Collections.shuffle(features, rand);

--- a/src/test/java/me/hydos/rosella/init/TestInitializationRegistry.java
+++ b/src/test/java/me/hydos/rosella/init/TestInitializationRegistry.java
@@ -1,0 +1,96 @@
+package me.hydos.rosella.init;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+
+public class TestInitializationRegistry {
+
+    @Test
+    void testApplicationFeatureSortingIndividual() {
+        List<String> names = List.of("testing:test1", "testing:test2", "testing:test3", "testing:test4");
+        List<ApplicationFeature> features = new ArrayList<>();
+        names.forEach(name -> features.add(new ApplicationFeature(name)));
+
+        InitializationRegistry registry = new InitializationRegistry();
+        features.forEach(registry::registerApplicationFeature);
+
+        List<ApplicationFeature> result = registry.getOrderedFeatures();
+        assertTrue(features.containsAll(result));
+    }
+
+    @Test
+    void testApplicationFeatureSortingSingeGroup() {
+        List<ApplicationFeature> features = new ArrayList<>();
+        features.add(new ApplicationFeature("testing:test1", List.of("testing:test2")));
+        features.add(new ApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
+        features.add(new ApplicationFeature("testing:test3"));
+        features.add(new ApplicationFeature("testing:test4"));
+
+        Random rand = new Random(479821392);
+        Collections.shuffle(features, rand);
+
+        InitializationRegistry registry = new InitializationRegistry();
+        features.forEach(registry::registerApplicationFeature);
+
+        List<ApplicationFeature> result = registry.getOrderedFeatures();
+
+        Set<String> previousFeatures = new HashSet<>();
+        for(ApplicationFeature feature : result) {
+            assertTrue(previousFeatures.containsAll(feature.dependencies), "Failed while testing " + feature.name);
+            previousFeatures.add(feature.name);
+        }
+    }
+
+    @Test
+    void testApplicationFeatureSortingMultiGroup() {
+        List<ApplicationFeature> features = new ArrayList<>();
+        features.add(new ApplicationFeature("testing:test1", List.of("testing:test2")));
+        features.add(new ApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
+        features.add(new ApplicationFeature("testing:test3"));
+        features.add(new ApplicationFeature("testing:test4"));
+
+        features.add(new ApplicationFeature("testing:test6", List.of("testing:test7")));
+        features.add(new ApplicationFeature("testing:test5"));
+        features.add(new ApplicationFeature("testing:test7", List.of("testing:test5")));
+
+        features.add(new ApplicationFeature("testing:test9"));
+
+        features.add(new ApplicationFeature("testing:test10"));
+        features.add(new ApplicationFeature("testing:test11", List.of("testing:test10")));
+        features.add(new ApplicationFeature("testing:test12", List.of("testing:test10")));
+        features.add(new ApplicationFeature("testing:test13", List.of("testing:test11", "testing:test12")));
+
+        Random rand = new Random(58234902);
+        Collections.shuffle(features, rand);
+
+        InitializationRegistry registry = new InitializationRegistry();
+        features.forEach(registry::registerApplicationFeature);
+
+        List<ApplicationFeature> result = registry.getOrderedFeatures();
+
+        Set<String> previousFeatures = new HashSet<>();
+        for(ApplicationFeature feature : result) {
+            assertTrue(previousFeatures.containsAll(feature.dependencies), "Failed while testing " + feature.name);
+            previousFeatures.add(feature.name);
+        }
+    }
+
+    @Test
+    void testApplicationFeatureSortingCycle() {
+        List<ApplicationFeature> features = new ArrayList<>();
+        features.add(new ApplicationFeature("testing:test1", List.of("testing:test2")));
+        features.add(new ApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
+        features.add(new ApplicationFeature("testing:test3"));
+        features.add(new ApplicationFeature("testing:test4", List.of("testing:test1")));
+
+        Random rand = new Random(479821392);
+        Collections.shuffle(features, rand);
+
+        InitializationRegistry registry = new InitializationRegistry();
+        features.forEach(registry::registerApplicationFeature);
+
+        assertThrows(RuntimeException.class, registry::getOrderedFeatures);
+    }
+}

--- a/src/test/java/me/hydos/rosella/init/TestInitializationRegistry.java
+++ b/src/test/java/me/hydos/rosella/init/TestInitializationRegistry.java
@@ -2,6 +2,7 @@ package me.hydos.rosella.init;
 
 import me.hydos.rosella.init.features.ApplicationFeature;
 import me.hydos.rosella.init.features.SimpleApplicationFeature;
+import me.hydos.rosella.util.NamedID;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -11,7 +12,7 @@ public class TestInitializationRegistry {
 
     @Test
     void testApplicationFeatureSortingIndividual() {
-        List<String> names = List.of("testing:test1", "testing:test2", "testing:test3", "testing:test4");
+        List<NamedID> names = List.of(new NamedID("testing:test1"), new NamedID("testing:test2"), new NamedID("testing:test3"), new NamedID("testing:test4"));
         List<ApplicationFeature> features = new ArrayList<>();
         names.forEach(name -> features.add(new SimpleApplicationFeature(name, null)));
 
@@ -25,10 +26,10 @@ public class TestInitializationRegistry {
     @Test
     void testApplicationFeatureSortingSingeGroup() {
         List<ApplicationFeature> features = new ArrayList<>();
-        features.add(new SimpleApplicationFeature("testing:test1", List.of("testing:test2")));
-        features.add(new SimpleApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
-        features.add(new SimpleApplicationFeature("testing:test3", null));
-        features.add(new SimpleApplicationFeature("testing:test4", null));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test1"), List.of(new NamedID("testing:test2"))));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test2"), List.of(new NamedID("testing:test3"), new NamedID("testing:test4"))));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test3"), null));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test4"), null));
 
         Random rand = new Random(479821392);
         Collections.shuffle(features, rand);
@@ -38,7 +39,7 @@ public class TestInitializationRegistry {
 
         List<ApplicationFeature> result = registry.getOrderedFeatures();
 
-        Set<String> previousFeatures = new HashSet<>();
+        Set<NamedID> previousFeatures = new HashSet<>();
         for(ApplicationFeature feature : result) {
             assertTrue(previousFeatures.containsAll(feature.dependencies), "Failed while testing " + feature.name);
             previousFeatures.add(feature.name);
@@ -48,21 +49,21 @@ public class TestInitializationRegistry {
     @Test
     void testApplicationFeatureSortingMultiGroup() {
         List<ApplicationFeature> features = new ArrayList<>();
-        features.add(new SimpleApplicationFeature("testing:test1", List.of("testing:test2")));
-        features.add(new SimpleApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
-        features.add(new SimpleApplicationFeature("testing:test3", null));
-        features.add(new SimpleApplicationFeature("testing:test4", null));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test1"), List.of(new NamedID("testing:test2"))));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test2"), List.of(new NamedID("testing:test3"), new NamedID("testing:test4"))));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test3"), null));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test4"), null));
 
-        features.add(new SimpleApplicationFeature("testing:test6", List.of("testing:test7")));
-        features.add(new SimpleApplicationFeature("testing:test5", null));
-        features.add(new SimpleApplicationFeature("testing:test7", List.of("testing:test5")));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test6"), List.of(new NamedID("testing:test7"))));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test5"), null));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test7"), List.of(new NamedID("testing:test5"))));
 
-        features.add(new SimpleApplicationFeature("testing:test9", null));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test9"), null));
 
-        features.add(new SimpleApplicationFeature("testing:test10", null));
-        features.add(new SimpleApplicationFeature("testing:test11", List.of("testing:test10")));
-        features.add(new SimpleApplicationFeature("testing:test12", List.of("testing:test10")));
-        features.add(new SimpleApplicationFeature("testing:test13", List.of("testing:test11", "testing:test12")));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test10"), null));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test11"), List.of(new NamedID("testing:test10"))));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test12"), List.of(new NamedID("testing:test10"))));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test13"), List.of(new NamedID("testing:test11"), new NamedID("testing:test12"))));
 
         Random rand = new Random(58234902);
         Collections.shuffle(features, rand);
@@ -72,7 +73,7 @@ public class TestInitializationRegistry {
 
         List<ApplicationFeature> result = registry.getOrderedFeatures();
 
-        Set<String> previousFeatures = new HashSet<>();
+        Set<NamedID> previousFeatures = new HashSet<>();
         for(ApplicationFeature feature : result) {
             assertTrue(previousFeatures.containsAll(feature.dependencies), "Failed while testing " + feature.name);
             previousFeatures.add(feature.name);
@@ -82,10 +83,10 @@ public class TestInitializationRegistry {
     @Test
     void testApplicationFeatureSortingCycle() {
         List<ApplicationFeature> features = new ArrayList<>();
-        features.add(new SimpleApplicationFeature("testing:test1", List.of("testing:test2")));
-        features.add(new SimpleApplicationFeature("testing:test2", List.of("testing:test3", "testing:test4")));
-        features.add(new SimpleApplicationFeature("testing:test3", null));
-        features.add(new SimpleApplicationFeature("testing:test4", List.of("testing:test1")));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test1"), List.of(new NamedID("testing:test2"))));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test2"), List.of(new NamedID("testing:test3"), new NamedID("testing:test4"))));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test3"), null));
+        features.add(new SimpleApplicationFeature(new NamedID("testing:test4"), List.of(new NamedID("testing:test1"))));
 
         Random rand = new Random(479821392);
         Collections.shuffle(features, rand);

--- a/src/test/java/me/hydos/rosella/init/TestInstanceBuilder.java
+++ b/src/test/java/me/hydos/rosella/init/TestInstanceBuilder.java
@@ -1,4 +1,35 @@
 package me.hydos.rosella.init;
 
+import me.hydos.rosella.annotations.RequiresVulkan;
+import org.junit.jupiter.api.Test;
+import org.lwjgl.vulkan.VK10;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 public class TestInstanceBuilder {
+
+    @Test
+    @RequiresVulkan
+    void testMinimalBuild() {
+        InitializationRegistry registry = new InitializationRegistry();
+
+        assertDoesNotThrow(() -> {
+            InstanceBuilder builder = new InstanceBuilder(registry);
+            VulkanInstance instance = builder.build("RosellaTests", VK10.VK_MAKE_VERSION(1, 0, 0));
+            instance.destroy();
+        });
+    }
+
+    @Test
+    @RequiresVulkan
+    void testEnableValidation() {
+        InitializationRegistry registry = new InitializationRegistry();
+        registry.enableValidation(true);
+
+        assertDoesNotThrow(() -> {
+            InstanceBuilder builder = new InstanceBuilder(registry);
+            VulkanInstance instance = builder.build("RosellaTests", VK10.VK_MAKE_VERSION(1, 0, 0));
+            instance.destroy();
+        });
+    }
 }

--- a/src/test/java/me/hydos/rosella/init/TestInstanceBuilder.java
+++ b/src/test/java/me/hydos/rosella/init/TestInstanceBuilder.java
@@ -1,0 +1,4 @@
+package me.hydos.rosella.init;
+
+public class TestInstanceBuilder {
+}

--- a/src/test/java/me/hydos/rosella/test_utils/VulkanTestInstance.java
+++ b/src/test/java/me/hydos/rosella/test_utils/VulkanTestInstance.java
@@ -1,0 +1,21 @@
+package me.hydos.rosella.test_utils;
+
+import me.hydos.rosella.init.InitializationRegistry;
+import me.hydos.rosella.init.InstanceBuilder;
+import me.hydos.rosella.init.VulkanInstance;
+import org.lwjgl.vulkan.VK10;
+
+public class VulkanTestInstance implements AutoCloseable {
+
+    public final VulkanInstance instance;
+
+    public VulkanTestInstance(InitializationRegistry registry) {
+        InstanceBuilder instanceBuilder = new InstanceBuilder(registry);
+        this.instance = instanceBuilder.build("RosellaTests", VK10.VK_MAKE_VERSION(1, 0, 0));
+    }
+
+    @Override
+    public void close() {
+        this.instance.destroy();
+    }
+}

--- a/src/test/java/me/hydos/rosella/test_utils/VulkanTestInstanceDevice.java
+++ b/src/test/java/me/hydos/rosella/test_utils/VulkanTestInstanceDevice.java
@@ -1,0 +1,28 @@
+package me.hydos.rosella.test_utils;
+
+import me.hydos.rosella.device.VulkanDevice;
+import me.hydos.rosella.init.DeviceBuilder;
+import me.hydos.rosella.init.InitializationRegistry;
+import me.hydos.rosella.init.InstanceBuilder;
+import me.hydos.rosella.init.VulkanInstance;
+import org.lwjgl.vulkan.VK10;
+
+public class VulkanTestInstanceDevice implements AutoCloseable {
+
+    public final VulkanInstance instance;
+    public final VulkanDevice device;
+
+    public VulkanTestInstanceDevice(InitializationRegistry registry) {
+        InstanceBuilder instanceBuilder = new InstanceBuilder(registry);
+        this.instance = instanceBuilder.build("RosellaTests", VK10.VK_MAKE_VERSION(1, 0, 0));
+
+        DeviceBuilder deviceBuilder = new DeviceBuilder(this.instance, registry);
+        this.device = deviceBuilder.build();
+    }
+
+    @Override
+    public void close() {
+        this.device.destroy();
+        this.instance.destroy();
+    }
+}


### PR DESCRIPTION
A mostly complete rewrite of the initialization process.

Instance and device creation now use the `InstanceBuilder` and `DeviceBuilder` classes to generate them. These classes take as an argument a `InitializationRegistry` which contains all the information needed to configure them. (only exception being the application name and version and im not sure if it should be added as well or not)

A new debug callback system has been added that can dynamically add and remove callbacks and some utilities to make callback handling easier were added.

Instance creation is straightforward. You can specify a list of required and optional extensions/layers to enable. A boolean flag to enable validation is also added and should always be preferred over just adding the validation layers to the required layers. The flag automatically does that as well as other things in the background so it is a lot more flexible. Finally it is possible to register as many debug callbacks as wanted and they do not require validation to be enabled to work.

Device creation is a lot more powerful now. It now uses the `ApplicationFeature` class to define a set of device capabilities that represent a feature in the application. The features can be dependant on each other and can return information to the application to define complex and dynamic feature sets. Everything related to device configuration now happens using these classes. Testing if the device has some set of capabilities is done by testing if a corresponding `ApplicationFeature` has been enabled. Getting `VulkanQueues` is done by making queue requests during the `configureDevice` call in a ApplicationFeature. etc.

Since ApplicationFeatures can be dependant on each other it is possible to define some that dont actually configure anything but just check if some capability exists. Other features can then depend on it and dont have to check for that capability themselves. The `Graphics` feature is an example of this.

ApplicationFeatures can be marked as required in which case a device will be rejected if it does not support all required ApplicationFeatures. This can be used by the application or rosella to define a minimum wanted feature set.

The RosellaLegacy feature enables everything the old initialization code did and is only used for backwards compatibility. Once the new graph system is fully in place it (together with a lot of other code) should be removed.
