### PR TITLE
Fix re-creating the swapchain causing a crash

### DIFF
--- a/src/main/java/graphics/kiln/rosella/render/fbo/FboManager.java
+++ b/src/main/java/graphics/kiln/rosella/render/fbo/FboManager.java
@@ -31,6 +31,16 @@ public class FboManager {
         for (FrameBufferObject fbo : fbos) {
             fbo.free(common);
         }
+
+        // Since we've just freed all of these, they can't be used for anything else so keeping them
+        // around is just trouble waiting to happen (notably, calling free twice would result in
+        // double-freeing all the FBOs).
+        // Note that clearing mainFbo does mean that it's legal to call setMainFbo again - while this
+        // is ultimately required to re-create the swapchain if the window is resized, it does mean
+        // no-one else should references to the main FBO.
+        fbos.clear();
+        mainFbo = null;
+        activeFbo = null;
     }
 
     public void recreateSwapchainImageViews(Swapchain swapchain, VkCommon common) {

--- a/src/main/java/graphics/kiln/rosella/render/renderer/Renderer.java
+++ b/src/main/java/graphics/kiln/rosella/render/renderer/Renderer.java
@@ -203,14 +203,6 @@ public class Renderer {
     }
 
     public void freeSwapChain() {
-        for (RawShaderProgram shader : common.shaderManager.getCachedShaders().keySet()) {
-            if (shader.getDescriptorPool() != VK_NULL_HANDLE) {
-                // TODO: make descriptor pool a class
-                vkDestroyDescriptorPool(rosella.common.device.getRawDevice(), shader.getDescriptorPool(), null);
-                shader.setDescriptorPool(VK_NULL_HANDLE);
-            }
-        }
-
         for (FrameBufferObject fbo : common.fboManager.fbos) {
             fbo.clearCommandBuffers(rosella.common.device, commandPool);
         }


### PR DESCRIPTION
As per the commit message:

Previously, when the swapchain was re-created (which notably occurs in
Blaze4D when the main window is resized) the application would crash
with FboManager.setMainFbo complaining that a main FBO was already set.

This was caused by not properly clearing references to the old FBOs that
were already set. Clearing those out allows us to set the new FBO, but
still won't allow a new one to be set without clearing all of the FBOs.

I've had a look and can't find any reason why it would, but it's
possible that changing the main FBO could cause some other issue I
didn't notice.

Additionally, this patch avoids deleting the descriptor pools while
freeing the swapchain. They're freed by the shaders (so shouldn't cause
a resource leak on shutdown), and the shaders themselves aren't freed
when the swapchain is freed. This was previously being done incorrectly
anyway, since it left descriptor sets still attached to the now-deleted
pool - this would cause a validation failure (and on my NVidia drivers,
a crash) when freeing those descriptor sets.

I can't think of any reason why the descriptor pools would need to be
freed when deleting the swapchain (though I'm not especially familier
with Vulkan so I may be wrong about this). While I think you can have
descriptor sets that point to the FBOs or the swapchain images, those
can and should be deleted by themselves.